### PR TITLE
Implement syntax parser and integrate driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+pytest_cache/
+.mypy_cache/
+*.log
+.idea/
+.vscode/
+venv/
+ENV/
+*.swp
+.DS_Store
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 MxScript
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/driver/main.py
+++ b/src/driver/main.py
@@ -1,0 +1,27 @@
+"""Command-line interface for testing the lexer and parser."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ..lexer import TokenStream, tokenize
+from ..syntax_parser import Parser, dump_ast
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python -m src.driver.main <source-file>")
+        return
+
+    path = Path(sys.argv[1])
+    source = path.read_text()
+    tokens = tokenize(source)
+    stream = TokenStream(tokens)
+    parser = Parser(stream)
+    ast = parser.parse()
+    print(dump_ast(ast))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lexer/Token.py
+++ b/src/lexer/Token.py
@@ -1,12 +1,17 @@
-# token.py
+"""Basic token representation used by the lexer."""
+
 from dataclasses import dataclass
+
 
 @dataclass
 class Token:
-    tk_type: str     # Token 的類型, 例如 'INTEGER', 'KEYWORD_LET', 'OPERATOR'
-    value: str    # Token 的實際文本值, 例如 '10', 'let', '+'
-    line: int     # Token 所在的行號
-    col: int      # Token 所在的列號
+    """Represents a single lexeme in the source file."""
 
-    def __repr__(self):
-        return f"Token({self.type}, '{self.value}', at {self.line}:{self.col})"
+    tk_type: str  # Token 的類型, 例如 'INTEGER', 'KEYWORD_LET', 'OPERATOR'
+    value: str  # Token 的實際文本值, 例如 '10', 'let', '+'
+    line: int  # Token 所在的行號
+    col: int  # Token 所在的列號
+
+    def __repr__(self) -> str:  # pragma: no cover - simple helper
+        return f"Token({self.tk_type}, '{self.value}', at {self.line}:{self.col})"
+

--- a/src/lexer/Tokenizer.py
+++ b/src/lexer/Tokenizer.py
@@ -1,0 +1,213 @@
+"""Simple tokenizer for the MxScript language."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .Token import Token
+
+
+KEYWORDS = {
+    "import",
+    "as",
+    "static",
+    "dynamic",
+    "let",
+    "mut",
+    "func",
+    "class",
+    "type",
+    "enum",
+    "public",
+    "private",
+    "operator",
+    "if",
+    "else",
+    "for",
+    "in",
+    "loop",
+    "break",
+    "return",
+    "raise",
+    "match",
+    "case",
+    "nil",
+    "@@",  # for annotations
+}
+
+
+OPERATORS = {
+    "==",
+    "!=",
+    ">=",
+    "<=",
+    "+=",
+    "-=",
+    "*=",
+    "/=",
+    "&&",
+    "||",
+    "->",
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "=",
+    ">",
+    "<",
+    "!",
+    "?",
+    ".",
+    ",",
+    ":",
+    ";",
+    "(",")",
+    "{",
+    "}",
+    "[",
+    "]",
+}
+
+
+class Tokenizer:
+    """Converts source text into a stream of :class:`Token` objects."""
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+    def tokenize(self) -> List[Token]:
+        tokens: List[Token] = []
+        i = 0
+        line = 1
+        col = 1
+        length = len(self.source)
+
+        def current_char() -> str:
+            return self.source[i] if i < length else ""
+
+        while i < length:
+            ch = current_char()
+
+            # Whitespace handling
+            if ch in " \t\r":
+                i += 1
+                col += 1
+                continue
+            if ch == "\n":
+                i += 1
+                line += 1
+                col = 1
+                continue
+
+            # Comments
+            if ch == "/" and i + 1 < length and self.source[i + 1] in {"/", "*"}:
+                start_line, start_col = line, col
+                if self.source[i + 1] == "/":
+                    i += 2
+                    col += 2
+                    while i < length and self.source[i] != "\n":
+                        i += 1
+                        col += 1
+                    tokens.append(Token("COMMENT", "", start_line, start_col))
+                    continue
+                else:
+                    # multiline comment
+                    i += 2
+                    col += 2
+                    while i < length and not (
+                        self.source[i] == "*" and i + 1 < length and self.source[i + 1] == "/"
+                    ):
+                        if self.source[i] == "\n":
+                            line += 1
+                            col = 1
+                            i += 1
+                            continue
+                        i += 1
+                        col += 1
+                    i += 2
+                    col += 2
+                    tokens.append(Token("COMMENT", "", start_line, start_col))
+                    continue
+
+            # String literal
+            if ch == '"':
+                start_line, start_col = line, col
+                i += 1
+                col += 1
+                literal = ""
+                while i < length and self.source[i] != '"':
+                    if self.source[i] == "\n":
+                        line += 1
+                        col = 1
+                    literal += self.source[i]
+                    i += 1
+                    col += 1
+                i += 1  # consume closing quote
+                col += 1
+                tokens.append(Token("STRING", literal, start_line, start_col))
+                continue
+
+            # Numbers
+            if ch.isdigit():
+                start_line, start_col = line, col
+                num = ch
+                i += 1
+                col += 1
+                while i < length and self.source[i].isdigit():
+                    num += self.source[i]
+                    i += 1
+                    col += 1
+                if i < length and self.source[i] == ".":
+                    num += "."
+                    i += 1
+                    col += 1
+                    while i < length and self.source[i].isdigit():
+                        num += self.source[i]
+                        i += 1
+                        col += 1
+                    tokens.append(Token("FLOAT", num, start_line, start_col))
+                else:
+                    tokens.append(Token("INTEGER", num, start_line, start_col))
+                continue
+
+            # Identifier or keyword
+            if ch.isalpha() or ch == "_":
+                start_line, start_col = line, col
+                ident = ch
+                i += 1
+                col += 1
+                while i < length and (self.source[i].isalnum() or self.source[i] == "_"):
+                    ident += self.source[i]
+                    i += 1
+                    col += 1
+                tk_type = "KEYWORD" if ident in KEYWORDS else "IDENTIFIER"
+                tokens.append(Token(tk_type, ident, start_line, start_col))
+                continue
+
+            # Operators and punctuation - match longest first
+            matched = False
+            for op in sorted(OPERATORS, key=len, reverse=True):
+                if self.source.startswith(op, i):
+                    tokens.append(Token("OPERATOR", op, line, col))
+                    i += len(op)
+                    col += len(op)
+                    matched = True
+                    break
+            if matched:
+                continue
+
+            # Unknown characters
+            tokens.append(Token("UNKNOWN", ch, line, col))
+            i += 1
+            col += 1
+
+        tokens.append(Token("EOF", "", line, col))
+        return tokens
+
+
+def tokenize(source: str) -> List[Token]:
+    """Convenience function returning a list of tokens."""
+
+    return Tokenizer(source).tokenize()
+

--- a/src/lexer/__init__.py
+++ b/src/lexer/__init__.py
@@ -1,0 +1,7 @@
+"""Lexer package providing tokenization utilities."""
+
+from .Token import Token
+from .Tokenizer import Tokenizer, tokenize
+from .token_stream import TokenStream
+
+__all__ = ["Token", "Tokenizer", "tokenize", "TokenStream"]

--- a/src/lexer/token_stream.py
+++ b/src/lexer/token_stream.py
@@ -1,0 +1,41 @@
+"""Utility container for navigating a list of tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from .Token import Token
+
+
+@dataclass
+class TokenStream:
+    """Simple stream wrapper around a list of tokens."""
+
+    tokens: List[Token]
+    position: int = 0
+
+    def peek(self, offset: int = 0) -> Optional[Token]:
+        index = self.position + offset
+        if 0 <= index < len(self.tokens):
+            return self.tokens[index]
+        return None
+
+    def next(self) -> Optional[Token]:
+        tok = self.peek()
+        if tok is not None:
+            self.position += 1
+        return tok
+
+    def expect(self, tk_type: str, value: Optional[str] = None) -> Token:
+        token = self.next()
+        if token is None:
+            raise SyntaxError(f"Expected {tk_type}, got EOF")
+        if token.tk_type != tk_type or (value is not None and token.value != value):
+            raise SyntaxError(f"Expected {tk_type} '{value}', got {token}")
+        return token
+
+    def __iter__(self) -> Iterable[Token]:
+        while self.position < len(self.tokens):
+            yield self.next()
+

--- a/src/syntax_parser/__init__.py
+++ b/src/syntax_parser/__init__.py
@@ -1,0 +1,23 @@
+from .parser import Parser
+from .utils import dump_ast
+from .ast import (
+    Program,
+    LetStmt,
+    ExprStmt,
+    Identifier,
+    Integer,
+    BinaryOp,
+    UnaryOp,
+)
+
+__all__ = [
+    "Parser",
+    "dump_ast",
+    "Program",
+    "LetStmt",
+    "ExprStmt",
+    "Identifier",
+    "Integer",
+    "BinaryOp",
+    "UnaryOp",
+]

--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+class Node:
+    """Base class for all AST nodes."""
+
+
+@dataclass
+class Program(Node):
+    statements: List["Statement"]
+
+
+class Statement(Node):
+    pass
+
+
+@dataclass
+class LetStmt(Statement):
+    name: str
+    value: "Expression"
+
+
+@dataclass
+class ExprStmt(Statement):
+    expr: "Expression"
+
+
+class Expression(Node):
+    pass
+
+
+@dataclass
+class Identifier(Expression):
+    name: str
+
+
+@dataclass
+class Integer(Expression):
+    value: int
+
+
+@dataclass
+class BinaryOp(Expression):
+    left: Expression
+    op: str
+    right: Expression
+
+
+@dataclass
+class UnaryOp(Expression):
+    op: str
+    operand: Expression

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from ..lexer import TokenStream
+from .ast import (
+    BinaryOp,
+    ExprStmt,
+    Identifier,
+    Integer,
+    LetStmt,
+    Program,
+)
+
+BINARY_PRECEDENCE: Dict[str, int] = {
+    '||': 1,
+    '&&': 2,
+    '==': 3,
+    '!=': 3,
+    '>=': 4,
+    '<=': 4,
+    '>': 4,
+    '<': 4,
+    '+': 5,
+    '-': 5,
+    '*': 6,
+    '/': 6,
+    '%': 6,
+}
+
+
+class Parser:
+    """Very small recursive descent parser building an AST."""
+
+    def __init__(self, stream: TokenStream) -> None:
+        self.stream = stream
+
+    def parse(self) -> Program:
+        statements = []
+        while self.stream.peek() and self.stream.peek().tk_type != 'EOF':
+            statements.append(self.parse_statement())
+        return Program(statements)
+
+    def parse_statement(self):
+        tok = self.stream.peek()
+        if tok.tk_type == 'KEYWORD' and tok.value == 'let':
+            return self.parse_let()
+        else:
+            expr = self.parse_expression()
+            self.stream.expect('OPERATOR', ';')
+            return ExprStmt(expr)
+
+    def parse_let(self) -> LetStmt:
+        self.stream.expect('KEYWORD', 'let')
+        # optional 'mut' ignored for now
+        name = self.stream.expect('IDENTIFIER').value
+        self.stream.expect('OPERATOR', '=')
+        value = self.parse_expression()
+        self.stream.expect('OPERATOR', ';')
+        return LetStmt(name, value)
+
+    def parse_expression(self, precedence: int = 1):
+        expr = self.parse_primary()
+        while True:
+            tok = self.stream.peek()
+            if (
+                tok
+                and tok.tk_type == 'OPERATOR'
+                and tok.value in BINARY_PRECEDENCE
+                and BINARY_PRECEDENCE[tok.value] >= precedence
+            ):
+                op = tok.value
+                self.stream.next()
+                right = self.parse_expression(BINARY_PRECEDENCE[op] + 1)
+                expr = BinaryOp(expr, op, right)
+            else:
+                break
+        return expr
+
+    def parse_primary(self):
+        tok = self.stream.peek()
+        if tok.tk_type == 'INTEGER':
+            self.stream.next()
+            return Integer(int(tok.value))
+        if tok.tk_type == 'IDENTIFIER':
+            self.stream.next()
+            return Identifier(tok.value)
+        if tok.tk_type == 'OPERATOR' and tok.value == '(':
+            self.stream.next()
+            expr = self.parse_expression()
+            self.stream.expect('OPERATOR', ')')
+            return expr
+        raise SyntaxError(f'Unexpected token {tok}')

--- a/src/syntax_parser/utils.py
+++ b/src/syntax_parser/utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from .ast import BinaryOp, ExprStmt, Identifier, Integer, LetStmt, Program, UnaryOp
+
+
+def dump_ast(node, indent: int = 0) -> str:
+    """Return a readable multi-line string representation of the AST."""
+    prefix = "  " * indent
+    if isinstance(node, Program):
+        lines = [prefix + "Program"]
+        for stmt in node.statements:
+            lines.append(dump_ast(stmt, indent + 1))
+        return "\n".join(lines)
+    if isinstance(node, LetStmt):
+        lines = [prefix + f"LetStmt(name={node.name})", dump_ast(node.value, indent + 1)]
+        return "\n".join(lines)
+    if isinstance(node, ExprStmt):
+        lines = [prefix + "ExprStmt", dump_ast(node.expr, indent + 1)]
+        return "\n".join(lines)
+    if isinstance(node, Integer):
+        return prefix + f"Integer({node.value})"
+    if isinstance(node, Identifier):
+        return prefix + f"Identifier({node.name})"
+    if isinstance(node, BinaryOp):
+        lines = [prefix + f"BinaryOp({node.op})", dump_ast(node.left, indent + 1), dump_ast(node.right, indent + 1)]
+        return "\n".join(lines)
+    if isinstance(node, UnaryOp):
+        lines = [prefix + f"UnaryOp({node.op})", dump_ast(node.operand, indent + 1)]
+        return "\n".join(lines)
+    return prefix + repr(node)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.lexer import TokenStream, tokenize
+from src.syntax_parser import (
+    BinaryOp,
+    ExprStmt,
+    Integer,
+    LetStmt,
+    Parser,
+)
+
+
+def parse(src: str):
+    tokens = tokenize(src)
+    stream = TokenStream(tokens)
+    return Parser(stream).parse()
+
+
+def test_parse_let_statement():
+    program = parse("let x = 42;")
+    assert len(program.statements) == 1
+    stmt = program.statements[0]
+    assert isinstance(stmt, LetStmt)
+    assert stmt.name == "x"
+    assert isinstance(stmt.value, Integer)
+    assert stmt.value.value == 42
+
+
+def test_operator_precedence():
+    program = parse("1 + 2 * 3;")
+    stmt = program.statements[0]
+    assert isinstance(stmt, ExprStmt)
+    expr = stmt.expr
+    assert isinstance(expr, BinaryOp)
+    assert expr.op == "+"
+    assert isinstance(expr.right, BinaryOp)
+    assert expr.right.op == "*"
+    assert isinstance(expr.right.left, Integer)
+    assert expr.right.left.value == 2

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.lexer import TokenStream, tokenize
+
+
+def test_simple_tokenization():
+    tokens = tokenize("let x = 10;")
+    types = [t.tk_type for t in tokens]
+    values = [t.value for t in tokens]
+    assert types[:5] == ["KEYWORD", "IDENTIFIER", "OPERATOR", "INTEGER", "OPERATOR"]
+    assert values[:5] == ["let", "x", "=", "10", ";"]
+    assert tokens[-1].tk_type == "EOF"
+
+
+def test_token_stream_navigation():
+    tokens = tokenize("let x = 1;")
+    stream = TokenStream(tokens)
+    assert stream.peek().value == "let"
+    stream.expect("KEYWORD", "let")
+    assert stream.next().tk_type == "IDENTIFIER"
+    stream.expect("OPERATOR", "=")
+    stream.expect("INTEGER", "1")
+    stream.expect("OPERATOR", ";")
+    assert stream.next().tk_type == "EOF"


### PR DESCRIPTION
## Summary
- add project-wide .gitignore and MIT license
- implement basic AST nodes and parser
- provide AST dumping utility
- wire lexer and parser together in driver
- include parser unit tests

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860d9254b9c832199ef197afbed3c02