### PR TITLE
Add LLVM IR backend

### DIFF
--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -10,6 +10,8 @@ from .llir import (
     compile_program,
     execute,
     optimize,
+    to_llvm_ir,
+    execute_llvm,
 )
 
 __all__ = [
@@ -24,4 +26,6 @@ __all__ = [
     "compile_program",
     "optimize",
     "execute",
+    "to_llvm_ir",
+    "execute_llvm",
 ]

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.lexer import TokenStream, tokenize
+from src.syntax_parser import Parser
+from src.semantic_analyzer import SemanticAnalyzer
+from src.backend import compile_program, optimize, execute_llvm
+
+
+def compile_and_run(src: str) -> int:
+    tokens = tokenize(src)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+    SemanticAnalyzer().analyze(ast)
+    ir_prog = optimize(compile_program(ast))
+    return execute_llvm(ir_prog)
+
+
+def test_llvm_backend_addition():
+    result = compile_and_run("let x = 1 + 2; x + 3;")
+    assert result == 6


### PR DESCRIPTION
## Summary
- support conversion of ProgramIR to LLVM IR via `to_llvm_ir`
- allow executing LLVM IR with `execute_llvm`
- export new helpers in backend package
- add tests for LLVM backend

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6860ebb01fc0832193fe2980c8b5efaf