### PR TITLE
Support # comments and better error reporting

### DIFF
--- a/demo_program/examples.mxs
+++ b/demo_program/examples.mxs
@@ -1,10 +1,10 @@
-// File: examples.mx
-// Contains several example programs to test different features of the MxScript language.
+# File: examples.mx
+# Contains several example programs to test different features of the MxScript language.
 
-// =================================================================
-// Example 1: Hello World
-// Tests: Basic function definition, imports, static binding, I/O.
-// =================================================================
+# =================================================================
+# Example 1: Hello World
+# Tests: Basic function definition, imports, static binding, I/O.
+# =================================================================
 import std.io as io;
 static let println = io.println;
 
@@ -13,10 +13,10 @@ func hello_world() -> nil {
 }
 
 
-// =================================================================
-// Example 2: Static Deterministic Fibonacci
-// Tests: @@static_deterministic, recursion, compile-time evaluation.
-// =================================================================
+# =================================================================
+# Example 2: Static Deterministic Fibonacci
+# Tests: @@static_deterministic, recursion, compile-time evaluation.
+# =================================================================
 @@static_deterministic
 func fib(n: int) -> int {
     if n <= 1 {
@@ -26,37 +26,37 @@ func fib(n: int) -> int {
 }
 
 func test_fib() -> nil {
-    // 编译器应该在编译时直接计算出 fib(10) 的值 (55)，
-    // 而不是在运行时进行递归调用。
+    # 编译器应该在编译时直接计算出 fib(10) 的值 (55)，
+    # 而不是在运行时进行递归调用。
     let fib_10 = fib(10);
-    println(fib_10); // Should print 55
+    println(fib_10); # Should print 55
 }
 
 
-// =================================================================
-// Example 3: Matrix Class & Error Handling
-// Tests: class, private/public, operator overloading, value-based errors,
-//        raise keyword, match expression for error handling.
-// =================================================================
+# =================================================================
+# Example 3: Matrix Class & Error Handling
+# Tests: class, private/public, operator overloading, value-based errors,
+#        raise keyword, match expression for error handling.
+# =================================================================
 
-// (假设 std.error 和 std.array 已被实现)
+# (假设 std.error 和 std.array 已被实现)
 import std.error.Error as Error;
 import std.array.make_array as make_array;
 
 class Matrix {
 public:
-    // 构造函数
+    # 构造函数
     Matrix(height: int, width: int) {
         self.height = height;
         self.width = width;
-        // 假设 `make_array` 创建一个指定大小、初始化为 0.0 的数组
+        # 假设 `make_array` 创建一个指定大小、初始化为 0.0 的数组
         self.data = make_array<float>(height * width, 0.0);
     }
 
-    // 重载 '+' 运算符
+    # 重载 '+' 运算符
     operator+(other: Matrix) -> Matrix | Error {
         if self.height != other.height || self.width != other.width {
-            // 返回一个 Error 对象，而不是抛出异常
+            # 返回一个 Error 对象，而不是抛出异常
             return raise Error("ShapeError", msg="Matrix dimensions do not match.");
         }
 
@@ -78,7 +78,7 @@ func test_matrix() -> nil {
     let m2 = Matrix(2, 3);
     let m3 = Matrix(3, 2);
 
-    // 成功的情况
+    # 成功的情况
     let success_result = match (m1 + m2) {
         case res: Matrix => {
             println("Matrix addition successful.");
@@ -86,11 +86,11 @@ func test_matrix() -> nil {
         }
         case err: Error => {
             println(err.msg);
-            nil; // 返回 nil
+            nil; # 返回 nil
         }
     };
     
-    // 失败的情况
+    # 失败的情况
     let failure_result = match (m1 + m3) {
         case res: Matrix => {
             println("This should not happen.");
@@ -98,67 +98,67 @@ func test_matrix() -> nil {
         }
         case err: Error => {
             println("Caught expected error:");
-            println(err.msg); // "Matrix dimensions do not match."
+            println(err.msg); # "Matrix dimensions do not match."
             nil;
         }
     };
 }
 
 
-// =================================================================
-// Example 4: Generic Function with @@template
-// Tests: @@template, generic function declaration, and instantiation.
-// =================================================================
+# =================================================================
+# Example 4: Generic Function with @@template
+# Tests: @@template, generic function declaration, and instantiation.
+# =================================================================
 @@template(type T)
 func swap(a: T, b: T) -> (T, T) {
     return (b, a);
 }
 
 func test_generics() -> nil {
-    // 实例化泛型函数来交换整数
+    # 实例化泛型函数来交换整数
     let (x, y) = swap<int>(10, 20);
-    println(x); // 20
-    println(y); // 10
+    println(x); # 20
+    println(y); # 10
 
-    // 实例化泛型函数来交换字符串
+    # 实例化泛型函数来交换字符串
     let (s1, s2) = swap<string>("hello", "world");
-    println(s1); // "world"
-    println(s2); // "hello"
+    println(s1); # "world"
+    println(s2); # "hello"
 }
 
 
-// =================================================================
-// Example 5: Panic
-// Tests: The panic mechanism for unrecoverable errors.
-// =================================================================
+# =================================================================
+# Example 5: Panic
+# Tests: The panic mechanism for unrecoverable errors.
+# =================================================================
 func cause_panic() -> nil {
     println("About to cause an unrecoverable error...");
-    // `panic=True` 会导致程序立即终止并打印错误信息。
+    # `panic=True` 会导致程序立即终止并打印错误信息。
     raise Error("FatalError", msg="System integrity compromised.", panic=True);
     println("This line will never be reached.");
 }
 
-// 主入口函数，用于调用所有测试
+# 主入口函数，用于调用所有测试
 func main() -> int {
     hello_world();
     test_fib();
     test_matrix();
     test_generics();
     
-    // 取消下面一行的注释来测试 panic 功能。
-    // cause_panic();
+    # 取消下面一行的注释来测试 panic 功能。
+    # cause_panic();
 
     return 0;
 }
 
 @@manual_optimize_level(level=3)
 func matrix_multiply(a: Matrix, b: Matrix) -> Matrix {
-    // ... implementation ...
+    # ... implementation ...
 }
 
-// For a less critical function, we might choose a lower level
-// to keep compile times fast.
+# For a less critical function, we might choose a lower level
+# to keep compile times fast.
 @@manual_optimize_level(level=1)
 func quick_utility_func() -> nil {
-    // ... implementation ...
+    # ... implementation ...
 }

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from .lexer import Token
+
+@dataclass
+class SyntaxErrorWithPos(Exception):
+    message: str
+    token: Token
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        return f"{self.message} at line {self.token.line}, column {self.token.col}"

--- a/src/lexer/Tokenizer.py
+++ b/src/lexer/Tokenizer.py
@@ -101,35 +101,34 @@ class Tokenizer:
                 col = 1
                 continue
 
-            # Comments
-            if ch == "/" and i + 1 < length and self.source[i + 1] in {"/", "*"}:
+            # Comments: '#' for single-line and '!##!' ... '!##!' for multi-line
+            if ch == "#":
                 start_line, start_col = line, col
-                if self.source[i + 1] == "/":
-                    i += 2
-                    col += 2
-                    while i < length and self.source[i] != "\n":
+                i += 1
+                col += 1
+                while i < length and self.source[i] != "\n":
+                    i += 1
+                    col += 1
+                tokens.append(Token("COMMENT", "", start_line, start_col))
+                continue
+
+            if self.source.startswith("!##!", i):
+                start_line, start_col = line, col
+                i += 4
+                col += 4
+                while i < length and not self.source.startswith("!##!", i):
+                    if self.source[i] == "\n":
+                        line += 1
+                        col = 1
                         i += 1
-                        col += 1
-                    tokens.append(Token("COMMENT", "", start_line, start_col))
-                    continue
-                else:
-                    # multiline comment
-                    i += 2
-                    col += 2
-                    while i < length and not (
-                        self.source[i] == "*" and i + 1 < length and self.source[i + 1] == "/"
-                    ):
-                        if self.source[i] == "\n":
-                            line += 1
-                            col = 1
-                            i += 1
-                            continue
-                        i += 1
-                        col += 1
-                    i += 2
-                    col += 2
-                    tokens.append(Token("COMMENT", "", start_line, start_col))
-                    continue
+                        continue
+                    i += 1
+                    col += 1
+                if i < length:
+                    i += 4
+                    col += 4
+                tokens.append(Token("COMMENT", "", start_line, start_col))
+                continue
 
             # Annotation token @@foo
             if ch == "@" and i + 1 < length and self.source[i + 1] == "@":

--- a/src/lexer/token_stream.py
+++ b/src/lexer/token_stream.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
 from .Token import Token
+from ..errors import SyntaxErrorWithPos
 
 
 @dataclass
@@ -30,9 +31,10 @@ class TokenStream:
     def expect(self, tk_type: str, value: Optional[str] = None) -> Token:
         token = self.next()
         if token is None:
-            raise SyntaxError(f"Expected {tk_type}, got EOF")
+            raise SyntaxErrorWithPos(f"Expected {tk_type}", self.tokens[-1])
         if token.tk_type != tk_type or (value is not None and token.value != value):
-            raise SyntaxError(f"Expected {tk_type} '{value}', got {token}")
+            msg = f"Expected {tk_type} '{value}'" if value else f"Expected {tk_type}"
+            raise SyntaxErrorWithPos(msg, token)
         return token
 
     def __iter__(self) -> Iterable[Token]:

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict
 
 from ..lexer import TokenStream
+from ..errors import SyntaxErrorWithPos
 from .ast import (
     BinaryOp,
     ExprStmt,
@@ -58,7 +59,10 @@ class Parser:
             if next_tok.tk_type == 'KEYWORD' and next_tok.value == 'func':
                 return self.parse_func_def(annotation)
             else:
-                raise SyntaxError('Annotation only supported before functions')
+                raise SyntaxErrorWithPos(
+                    'Annotation only supported before functions',
+                    next_tok,
+                )
         if tok.tk_type == 'KEYWORD' and tok.value == 'import':
             return self.parse_import()
         if tok.tk_type == 'KEYWORD' and tok.value == 'let':
@@ -162,7 +166,7 @@ class Parser:
             expr = self.parse_expression()
             self.stream.expect('OPERATOR', ')')
             return expr
-        raise SyntaxError(f'Unexpected token {tok}')
+        raise SyntaxErrorWithPos(f'Unexpected token {tok.tk_type}', tok)
 
     # ------------------------------------------------------------------
     # New parsing rules for functions and blocks

--- a/syntax/syntax.ebnf
+++ b/syntax/syntax.ebnf
@@ -146,4 +146,7 @@ generic_inst     = "<" , type_spec , { "," , type_spec } , ">" ;
 
 field_decl       = identifier_list , ":" , type_spec , ";" ;
 
+(* Comments are handled entirely by the lexer. The lexer recognizes two forms: *)
+(*  - '#'        : single line comment terminating at newline               *)
+(*  - '!##!' ... '!##!' : multi-line comment                                *)
 comment          = ? "Lexer-defined single or multi-line comment" ? ;

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -25,3 +25,9 @@ def test_token_stream_navigation():
     stream.expect("INTEGER", "1")
     stream.expect("OPERATOR", ";")
     assert stream.next().tk_type == "EOF"
+
+
+def test_hash_comment():
+    tokens = tokenize("# a comment\nlet x = 1;")
+    tk_types = [t.tk_type for t in tokens if t.tk_type != "COMMENT"]
+    assert tk_types[:4] == ["KEYWORD", "IDENTIFIER", "OPERATOR", "INTEGER"]


### PR DESCRIPTION
## Summary
- update lexer to handle `#` single-line and `!##!` multi-line comments
- document new comment syntax in grammar
- add SyntaxErrorWithPos helper and use it in TokenStream and parser
- adjust example programs to use `#` comment syntax
- test comment tokenization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861023858c0832193d3cf60f0aaea7c