### PR TITLE
Fix comment handling and dotted identifiers

### DIFF
--- a/src/lexer/token_stream.py
+++ b/src/lexer/token_stream.py
@@ -16,16 +16,28 @@ class TokenStream:
     tokens: List[Token]
     position: int = 0
 
+    def _skip_comments_from(self, index: int) -> int:
+        """Return the next index at or after *index* that is not a comment."""
+        while index < len(self.tokens) and self.tokens[index].tk_type == "COMMENT":
+            index += 1
+        return index
+
     def peek(self, offset: int = 0) -> Optional[Token]:
-        index = self.position + offset
-        if 0 <= index < len(self.tokens):
+        index = self._skip_comments_from(self.position)
+        while offset > 0 and index < len(self.tokens):
+            index += 1
+            index = self._skip_comments_from(index)
+            offset -= 1
+        if index < len(self.tokens):
             return self.tokens[index]
         return None
 
     def next(self) -> Optional[Token]:
         tok = self.peek()
         if tok is not None:
+            self.position = self._skip_comments_from(self.position)
             self.position += 1
+            self.position = self._skip_comments_from(self.position)
         return tok
 
     def expect(self, tk_type: str, value: Optional[str] = None) -> Token:

--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -94,7 +94,8 @@ class SemanticAnalyzer:
 
     def _visit_expression(self, expr: Expression) -> None:
         if isinstance(expr, Identifier):
-            if not self._is_defined(expr.name):
+            name = expr.name.split('.')[0]
+            if not self._is_defined(name):
                 raise SemanticError(f"Undefined variable '{expr.name}'")
         elif isinstance(expr, Integer):
             pass
@@ -107,7 +108,7 @@ class SemanticAnalyzer:
             self._visit_expression(expr.operand)
         elif isinstance(expr, FunctionCall):
             # Check that the function exists
-            if self.functions is not None and expr.name not in self.functions:
+            if '.' not in expr.name and self.functions is not None and expr.name not in self.functions:
                 raise SemanticError(f"Undefined function '{expr.name}'")
             for arg in expr.args:
                 self._visit_expression(arg)

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -149,7 +149,11 @@ class Parser:
             return String(tok.value)
         if tok.tk_type == 'IDENTIFIER':
             self.stream.next()
-            name = tok.value
+            parts = [tok.value]
+            while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '.':
+                self.stream.next()
+                parts.append(self.stream.expect('IDENTIFIER').value)
+            name = '.'.join(parts)
             if self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '(':
                 self.stream.next()
                 args = []
@@ -221,7 +225,12 @@ class Parser:
         return Parameter(names, type_name)
 
     def parse_type_spec(self) -> str:
-        parts = [self.stream.expect('IDENTIFIER').value]
+        tok = self.stream.peek()
+        if tok.tk_type == 'KEYWORD' and tok.value == 'nil':
+            self.stream.next()
+            parts = ['nil']
+        else:
+            parts = [self.stream.expect('IDENTIFIER').value]
         while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '.':
             self.stream.next()
             parts.append(self.stream.expect('IDENTIFIER').value)


### PR DESCRIPTION
## Summary
- ignore comment tokens during parsing
- support dotted names in expressions and types
- allow qualified identifiers in semantic analysis

## Testing
- `pytest -q`
- `python main.py demo_program/hello_world.mxs`

------
https://chatgpt.com/codex/tasks/task_b_686146621f8c8321946f37543b77da99