### PR TITLE
Fix comment handling and dotted identifiers

### DIFF
--- a/src/lexer/Tokenizer.py
+++ b/src/lexer/Tokenizer.py
@@ -48,6 +48,7 @@ OPERATORS = {
     "&&",
     "||",
     "->",
+    "=>",
     "+",
     "-",
     "*",
@@ -62,6 +63,7 @@ OPERATORS = {
     ",",
     ":",
     ";",
+    "..",
     "(",")",
     "{",
     "}",
@@ -165,7 +167,12 @@ class Tokenizer:
                     num += self.source[i]
                     i += 1
                     col += 1
-                if i < length and self.source[i] == ".":
+                if (
+                    i < length
+                    and self.source[i] == "."
+                    and i + 1 < length
+                    and self.source[i + 1].isdigit()
+                ):
                     num += "."
                     i += 1
                     col += 1

--- a/src/lexer/token_stream.py
+++ b/src/lexer/token_stream.py
@@ -16,16 +16,28 @@ class TokenStream:
     tokens: List[Token]
     position: int = 0
 
+    def _skip_comments_from(self, index: int) -> int:
+        """Return the next index at or after *index* that is not a comment."""
+        while index < len(self.tokens) and self.tokens[index].tk_type == "COMMENT":
+            index += 1
+        return index
+
     def peek(self, offset: int = 0) -> Optional[Token]:
-        index = self.position + offset
-        if 0 <= index < len(self.tokens):
+        index = self._skip_comments_from(self.position)
+        while offset > 0 and index < len(self.tokens):
+            index += 1
+            index = self._skip_comments_from(index)
+            offset -= 1
+        if index < len(self.tokens):
             return self.tokens[index]
         return None
 
     def next(self) -> Optional[Token]:
         tok = self.peek()
         if tok is not None:
+            self.position = self._skip_comments_from(self.position)
             self.position += 1
+            self.position = self._skip_comments_from(self.position)
         return tok
 
     def expect(self, tk_type: str, value: Optional[str] = None) -> Token:

--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -10,6 +10,10 @@ from ..syntax_parser.ast import (
     FuncDef,
     ForeignFuncDecl,
     ExprStmt,
+    ForInStmt,
+    RaiseStmt,
+    RaiseExpr,
+    MatchExpr,
     Identifier,
     Integer,
     String,
@@ -70,6 +74,14 @@ class SemanticAnalyzer:
             self._current_scope().add(stmt.name)
         elif isinstance(stmt, ExprStmt):
             self._visit_expression(stmt.expr)
+        elif isinstance(stmt, RaiseStmt):
+            self._visit_expression(stmt.expr)
+        elif isinstance(stmt, ForInStmt):
+            self._visit_expression(stmt.iterable)
+            self.variables_stack.append({stmt.var})
+            for s in stmt.body.statements:
+                self._visit_statement(s)
+            self.variables_stack.pop()
         elif isinstance(stmt, ImportStmt):
             # record alias so it can be referenced later
             if stmt.alias:
@@ -94,7 +106,8 @@ class SemanticAnalyzer:
 
     def _visit_expression(self, expr: Expression) -> None:
         if isinstance(expr, Identifier):
-            if not self._is_defined(expr.name):
+            name = expr.name.split('.')[0]
+            if not self._is_defined(name):
                 raise SemanticError(f"Undefined variable '{expr.name}'")
         elif isinstance(expr, Integer):
             pass
@@ -105,9 +118,21 @@ class SemanticAnalyzer:
             self._visit_expression(expr.right)
         elif isinstance(expr, UnaryOp):
             self._visit_expression(expr.operand)
+        elif isinstance(expr, RaiseExpr):
+            self._visit_expression(expr.expr)
+        elif isinstance(expr, MatchExpr):
+            self._visit_expression(expr.value)
+            for case in expr.cases:
+                self.variables_stack.append({case.name})
+                if isinstance(case.body, Expression):
+                    self._visit_expression(case.body)
+                else:
+                    for s in case.body.statements:
+                        self._visit_statement(s)
+                self.variables_stack.pop()
         elif isinstance(expr, FunctionCall):
             # Check that the function exists
-            if self.functions is not None and expr.name not in self.functions:
+            if '.' not in expr.name and self.functions is not None and expr.name not in self.functions:
                 raise SemanticError(f"Undefined function '{expr.name}'")
             for arg in expr.args:
                 self._visit_expression(arg)

--- a/src/syntax_parser/__init__.py
+++ b/src/syntax_parser/__init__.py
@@ -17,6 +17,11 @@ from .ast import (
     FunctionDecl,
     ForeignFuncDecl,
     FunctionCall,
+    ForInStmt,
+    RaiseStmt,
+    RaiseExpr,
+    MatchExpr,
+    MatchCase,
 )
 
 __all__ = [
@@ -38,4 +43,9 @@ __all__ = [
     "FunctionDecl",
     "ForeignFuncDecl",
     "FunctionCall",
+    "ForInStmt",
+    "RaiseStmt",
+    "RaiseExpr",
+    "MatchExpr",
+    "MatchCase",
 ]

--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -114,3 +114,38 @@ class FunctionCall(Expression):
     name: str
     args: List[Expression]
 
+
+@dataclass
+class ForInStmt(Statement):
+    """Represents a simple 'for' loop over an iterable expression."""
+
+    var: str
+    iterable: Expression
+    body: Block
+    is_mut: bool = False
+
+
+@dataclass
+class RaiseStmt(Statement):
+    """`raise` statement used for value-based error handling."""
+
+    expr: Expression
+
+
+@dataclass
+class RaiseExpr(Expression):
+    expr: Expression
+
+
+@dataclass
+class MatchCase(Node):
+    name: str
+    type_name: str
+    body: Block | Expression
+
+
+@dataclass
+class MatchExpr(Expression):
+    value: Expression
+    cases: List[MatchCase]
+

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -33,6 +33,7 @@ BINARY_PRECEDENCE: Dict[str, int] = {
     '<': 4,
     '+': 5,
     '-': 5,
+    '..': 5,
     '*': 6,
     '/': 6,
     '%': 6,
@@ -67,6 +68,10 @@ class Parser:
             return self.parse_import()
         if tok.tk_type == 'KEYWORD' and tok.value == 'let':
             return self.parse_let()
+        if tok.tk_type == 'KEYWORD' and tok.value == 'for':
+            return self.parse_for_in()
+        if tok.tk_type == 'KEYWORD' and tok.value == 'raise':
+            return self.parse_raise_stmt()
         if tok.tk_type == 'KEYWORD' and tok.value == 'func':
             return self.parse_func_def()
         if tok.tk_type == 'OPERATOR' and tok.value == '{':
@@ -97,6 +102,50 @@ class Parser:
         value = self.parse_expression()
         self.stream.expect('OPERATOR', ';')
         return LetStmt(name, value)
+
+    def parse_for_in(self):
+        self.stream.expect('KEYWORD', 'for')
+        is_mut = False
+        if self.stream.peek().tk_type == 'KEYWORD' and self.stream.peek().value == 'mut':
+            self.stream.next()
+            is_mut = True
+        var = self.stream.expect('IDENTIFIER').value
+        self.stream.expect('KEYWORD', 'in')
+        iterable = self.parse_expression()
+        body = self.parse_block()
+        from .ast import ForInStmt
+        return ForInStmt(var, iterable, body, is_mut)
+
+    def parse_raise_stmt(self):
+        self.stream.expect('KEYWORD', 'raise')
+        expr = self.parse_expression()
+        self.stream.expect('OPERATOR', ';')
+        from .ast import RaiseStmt
+        return RaiseStmt(expr)
+
+    def parse_match_expr(self):
+        self.stream.expect('KEYWORD', 'match')
+        self.stream.expect('OPERATOR', '(')
+        value = self.parse_expression()
+        self.stream.expect('OPERATOR', ')')
+        self.stream.expect('OPERATOR', '{')
+        cases = []
+        from .ast import MatchExpr, MatchCase
+        while self.stream.peek().tk_type == 'KEYWORD' and self.stream.peek().value == 'case':
+            self.stream.next()
+            name = self.stream.expect('IDENTIFIER').value
+            self.stream.expect('OPERATOR', ':')
+            type_name = self.parse_type_spec()
+            self.stream.expect('OPERATOR', '=>')
+            if self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '{':
+                body = self.parse_block()
+            else:
+                body = self.parse_expression()
+            if self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == ',':
+                self.stream.next()
+            cases.append(MatchCase(name, type_name, body))
+        self.stream.expect('OPERATOR', '}')
+        return MatchExpr(value, cases)
 
     def parse_import(self) -> ImportStmt:
         """Parse an import statement."""
@@ -147,9 +196,20 @@ class Parser:
         if tok.tk_type == 'STRING':
             self.stream.next()
             return String(tok.value)
+        if tok.tk_type == 'KEYWORD' and tok.value == 'raise':
+            self.stream.next()
+            expr = self.parse_expression()
+            from .ast import RaiseExpr
+            return RaiseExpr(expr)
+        if tok.tk_type == 'KEYWORD' and tok.value == 'match':
+            return self.parse_match_expr()
         if tok.tk_type == 'IDENTIFIER':
             self.stream.next()
-            name = tok.value
+            parts = [tok.value]
+            while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '.':
+                self.stream.next()
+                parts.append(self.stream.expect('IDENTIFIER').value)
+            name = '.'.join(parts)
             if self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '(':
                 self.stream.next()
                 args = []
@@ -221,7 +281,19 @@ class Parser:
         return Parameter(names, type_name)
 
     def parse_type_spec(self) -> str:
-        parts = [self.stream.expect('IDENTIFIER').value]
+        parts = [self._parse_single_type_spec()]
+        while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '|':
+            self.stream.next()
+            parts.append(self._parse_single_type_spec())
+        return ' | '.join(parts)
+
+    def _parse_single_type_spec(self) -> str:
+        tok = self.stream.peek()
+        if tok.tk_type == 'KEYWORD' and tok.value == 'nil':
+            self.stream.next()
+            parts = ['nil']
+        else:
+            parts = [self.stream.expect('IDENTIFIER').value]
         while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '.':
             self.stream.next()
             parts.append(self.stream.expect('IDENTIFIER').value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,6 +13,9 @@ from src.syntax_parser import (
     FuncDef,
     Block,
     ImportStmt,
+    ForInStmt,
+    RaiseStmt,
+    MatchExpr,
     Parser,
 )
 
@@ -88,4 +91,25 @@ def test_parse_import():
     assert isinstance(stmt, ImportStmt)
     assert stmt.module == "std.io"
     assert stmt.alias == "io"
+
+
+def test_parse_for_loop():
+    src = "for i in 0..10 { let x = i; }"
+    program = parse(src)
+    stmt = program.statements[0]
+    assert isinstance(stmt, ForInStmt)
+    assert stmt.var == "i"
+
+
+def test_parse_raise_stmt():
+    program = parse("raise 1;")
+    stmt = program.statements[0]
+    assert isinstance(stmt, RaiseStmt)
+
+
+def test_parse_match_expr():
+    program = parse("match (x) { case v: int => v, case s: string => 0 };")
+    stmt = program.statements[0]
+    assert isinstance(stmt, ExprStmt)
+    assert isinstance(stmt.expr, MatchExpr)
 


### PR DESCRIPTION
## Summary
- ignore comment tokens during parsing
- support dotted names in expressions and types
- allow qualified identifiers in semantic analysis
- add for loop, raise and match parsing with union type support

## Testing
- `pytest -q`
- `python main.py demo_program/hello_world.mxs`


------
https://chatgpt.com/codex/tasks/task_b_686146621f8c8321946f37543b77da99