### PR TITLE
Support !# comments in tokenizer

### DIFF
--- a/src/lexer/Tokenizer.py
+++ b/src/lexer/Tokenizer.py
@@ -103,7 +103,7 @@ class Tokenizer:
                 col = 1
                 continue
 
-            # Comments: '#' for single-line and '!##!' ... '!##!' for multi-line
+            # Comments: '#' for single-line, '!##!' ... '!##!' and '!#' ... '#!' for multi-line
             if ch == "#":
                 start_line, start_col = line, col
                 i += 1
@@ -129,6 +129,24 @@ class Tokenizer:
                 if i < length:
                     i += 4
                     col += 4
+                tokens.append(Token("COMMENT", "", start_line, start_col))
+                continue
+
+            if self.source.startswith("!#", i):
+                start_line, start_col = line, col
+                i += 2
+                col += 2
+                while i < length and not self.source.startswith("#!", i):
+                    if self.source[i] == "\n":
+                        line += 1
+                        col = 1
+                        i += 1
+                        continue
+                    i += 1
+                    col += 1
+                if i < length:
+                    i += 2
+                    col += 2
                 tokens.append(Token("COMMENT", "", start_line, start_col))
                 continue
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -31,3 +31,10 @@ def test_hash_comment():
     tokens = tokenize("# a comment\nlet x = 1;")
     tk_types = [t.tk_type for t in tokens if t.tk_type != "COMMENT"]
     assert tk_types[:4] == ["KEYWORD", "IDENTIFIER", "OPERATOR", "INTEGER"]
+
+
+def test_bang_hash_comment():
+    src = "!#\n multi line\n#!\nlet x = 1;"
+    tokens = tokenize(src)
+    tk_types = [t.tk_type for t in tokens if t.tk_type != "COMMENT"]
+    assert tk_types[:4] == ["KEYWORD", "IDENTIFIER", "OPERATOR", "INTEGER"]


### PR DESCRIPTION
## Summary
- extend tokenizer to handle comments starting with `!#` and ending with `#!`
- test new comment syntax in tokenizer tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686150b47bd88321afa437b23d88f523