### PR TITLE
Add string escape support and driver exit code

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
 from src.lexer import TokenStream, tokenize
 from src.syntax_parser import Parser, dump_ast
@@ -64,7 +65,7 @@ def main(argv: list[str] | None = None) -> None:
         result = execute_llvm(ir_prog)
 
     if result is not None:
-        print(result)
+        sys.exit(result)
 
 
 if __name__ == "__main__":

--- a/src/lexer/Tokenizer.py
+++ b/src/lexer/Tokenizer.py
@@ -164,12 +164,29 @@ class Tokenizer:
                 col += 1
                 literal = ""
                 while i < length and self.source[i] != '"':
+                    if self.source[i] == "\\":
+                        if i + 1 < length:
+                            esc = self.source[i + 1]
+                            if esc == "n":
+                                literal += "\n"
+                            elif esc == "t":
+                                literal += "\t"
+                            elif esc == '"':
+                                literal += '"'
+                            elif esc == "\\":
+                                literal += "\\"
+                            else:
+                                literal += esc
+                            i += 2
+                            col += 2
+                            continue
                     if self.source[i] == "\n":
                         line += 1
                         col = 1
+                    else:
+                        col += 1
                     literal += self.source[i]
                     i += 1
-                    col += 1
                 i += 1  # consume closing quote
                 col += 1
                 tokens.append(Token("STRING", literal, start_line, start_col))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+import main
+
+
+def test_driver_exit(tmp_path):
+    src = "func main() -> int { return 5; }"
+    path = tmp_path / "prog.mxs"
+    path.write_text(src)
+    with pytest.raises(SystemExit) as exc:
+        main.main([str(path)])
+    assert exc.value.code == 5

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -38,3 +38,10 @@ def test_bang_hash_comment():
     tokens = tokenize(src)
     tk_types = [t.tk_type for t in tokens if t.tk_type != "COMMENT"]
     assert tk_types[:4] == ["KEYWORD", "IDENTIFIER", "OPERATOR", "INTEGER"]
+
+
+def test_string_escape_sequences():
+    src = "\"foo\\nbar\\t\\\"baz\\\"\\\\\""
+    tokens = tokenize(src)
+    assert tokens[0].tk_type == "STRING"
+    assert tokens[0].value == 'foo\nbar\t"baz"\\'


### PR DESCRIPTION
## Summary
- extend tokenizer to interpret escape sequences in string literals
- run program result through `sys.exit` in driver
- test tokenizer escapes and driver exit behavior

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68615507f2ac8321a1561738f8f12ee1