### PR TITLE
Fix typed let parsing

### DIFF
--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -21,6 +21,8 @@ class Statement(Node):
 class LetStmt(Statement):
     name: str
     value: "Expression"
+    type_name: str | None = None
+    is_mut: bool = False
 
 
 @dataclass

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -103,12 +103,19 @@ class Parser:
 
     def parse_let(self) -> LetStmt:
         self.stream.expect('KEYWORD', 'let')
-        # optional 'mut' ignored for now
+        is_mut = False
+        if self.stream.peek().tk_type == 'KEYWORD' and self.stream.peek().value == 'mut':
+            self.stream.next()
+            is_mut = True
         name = self.stream.expect('IDENTIFIER').value
+        type_name = None
+        if self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == ':':
+            self.stream.next()
+            type_name = self.parse_type_spec()
         self.stream.expect('OPERATOR', '=')
         value = self.parse_expression()
         self.stream.expect('OPERATOR', ';')
-        return LetStmt(name, value)
+        return LetStmt(name, value, type_name, is_mut)
 
     def parse_binding(self, is_static: bool):
         self.stream.next()  # consume 'static' or 'dynamic'

--- a/src/syntax_parser/utils.py
+++ b/src/syntax_parser/utils.py
@@ -23,7 +23,13 @@ def dump_ast(node, indent: int = 0) -> str:
             lines.append(dump_ast(stmt, indent + 1))
         return "\n".join(lines)
     if isinstance(node, LetStmt):
-        lines = [prefix + f"LetStmt(name={node.name})", dump_ast(node.value, indent + 1)]
+        extra = []
+        if node.type_name is not None:
+            extra.append(f"type={node.type_name}")
+        if node.is_mut:
+            extra.append("mut")
+        desc = f"LetStmt(name={node.name}" + (", " + ", ".join(extra) if extra else "") + ")"
+        lines = [prefix + desc, dump_ast(node.value, indent + 1)]
         return "\n".join(lines)
     if isinstance(node, BindingStmt):
         kind = "static" if node.is_static else "dynamic"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,6 +38,22 @@ def test_parse_let_statement():
     assert stmt.value.value == 42
 
 
+def test_parse_typed_let():
+    program = parse("let x: int = 42;")
+    stmt = program.statements[0]
+    assert isinstance(stmt, LetStmt)
+    assert stmt.name == "x"
+    assert stmt.type_name == "int"
+    assert isinstance(stmt.value, Integer)
+
+
+def test_parse_mutable_let():
+    program = parse("let mut y = 1;")
+    stmt = program.statements[0]
+    assert isinstance(stmt, LetStmt)
+    assert stmt.is_mut
+
+
 def test_parse_static_binding():
     program = parse("static let x = 1;")
     stmt = program.statements[0]


### PR DESCRIPTION
## Summary
- support type annotations and `mut` keyword in let statements
- extend AST `LetStmt` with `type_name` and `is_mut`
- improve AST dump for let statements
- test parsing for typed and mutable lets

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llvmlite')*

------
https://chatgpt.com/codex/tasks/task_b_686156fc9eec8321a715ae61265dcbf3