### PR TITLE
Add separated example programs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,13 @@ can parse and execute `.mxs` files:
 python main.py demo_program/hello_world.mxs
 ```
 
+Additional examples are located in `demo_program/examples`. Each file focuses on
+a single feature. You can run them the same way:
+
+```bash
+python main.py demo_program/examples/generic_swap.mxs
+```
+
 To execute using the LLVM backend, pass `--compile-mode llvm`.
 
 ## Development

--- a/demo_program/examples/README.md
+++ b/demo_program/examples/README.md
@@ -1,0 +1,18 @@
+# MxScript Examples
+
+This directory contains small programs that demonstrate individual language features. Run any file with `python main.py <path>`.
+
+| File | Highlights |
+| --- | --- |
+| `hello_world.mxs` | Basic functions and I/O |
+| `static_fib.mxs` | `@@static_deterministic` and recursion |
+| `matrix_class.mxs` | Classes, operator overloading, errors |
+| `generic_swap.mxs` | Generic functions with `@@template` |
+| `panic_example.mxs` | Unrecoverable errors and `panic` |
+| `manual_optimization.mxs` | `@@manual_optimize_level` attribute |
+
+Example usage:
+
+```bash
+python main.py demo_program/examples/generic_swap.mxs
+```

--- a/demo_program/examples/generic_swap.mxs
+++ b/demo_program/examples/generic_swap.mxs
@@ -1,0 +1,21 @@
+# Example 4: Generic Function with @@template
+# Demonstrates @@template, generic function declaration and instantiation.
+
+import std.io as io;
+static let println = io.println;
+
+@@template(type T)
+func swap(a: T, b: T) -> (T, T) {
+    return (b, a);
+}
+
+func main() -> int {
+    let (x, y) = swap<int>(10, 20);
+    println(x);
+    println(y);
+
+    let (s1, s2) = swap<string>("hello", "world");
+    println(s1);
+    println(s2);
+    return 0;
+}

--- a/demo_program/examples/hello_world.mxs
+++ b/demo_program/examples/hello_world.mxs
@@ -1,0 +1,14 @@
+# Example 1: Hello World
+# Demonstrates basic function definition, imports, static binding and I/O.
+
+import std.io as io;
+static let println = io.println;
+
+func hello_world() -> nil {
+    println("Hello, World!");
+}
+
+func main() -> int {
+    hello_world();
+    return 0;
+}

--- a/demo_program/examples/manual_optimization.mxs
+++ b/demo_program/examples/manual_optimization.mxs
@@ -1,0 +1,14 @@
+# Example 6: Manual Optimization Levels
+# Demonstrates the @@manual_optimize_level attribute.
+
+class Matrix {}
+
+@@manual_optimize_level(level=3)
+func matrix_multiply(a: Matrix, b: Matrix) -> Matrix {
+    # ... implementation ...
+}
+
+@@manual_optimize_level(level=1)
+func quick_utility_func() -> nil {
+    # ... implementation ...
+}

--- a/demo_program/examples/matrix_class.mxs
+++ b/demo_program/examples/matrix_class.mxs
@@ -1,0 +1,65 @@
+# Example 3: Matrix Class & Error Handling
+# Demonstrates classes, operator overloading and value-based error handling.
+
+import std.io as io;
+import std.error.Error as Error;
+import std.array.make_array as make_array;
+
+static let println = io.println;
+
+class Matrix {
+public:
+    Matrix(height: int, width: int) {
+        self.height = height;
+        self.width = width;
+        self.data = make_array<float>(height * width, 0.0);
+    }
+
+    operator+(other: Matrix) -> Matrix | Error {
+        if self.height != other.height || self.width != other.width {
+            return raise Error("ShapeError", msg="Matrix dimensions do not match.");
+        }
+
+        let mut result = Matrix(self.height, self.width);
+        for i in 0..(self.height * self.width) {
+            result.data[i] = self.data[i] + other.data[i];
+        }
+        return result;
+    }
+
+private:
+    let height: int;
+    let width: int;
+    let mut data: [float];
+}
+
+func main() -> int {
+    let m1 = Matrix(2, 3);
+    let m2 = Matrix(2, 3);
+    let m3 = Matrix(3, 2);
+
+    let success_result = match (m1 + m2) {
+        case res: Matrix => {
+            println("Matrix addition successful.");
+            res;
+        }
+        case err: Error => {
+            println(err.msg);
+            nil;
+        }
+    };
+
+    let failure_result = match (m1 + m3) {
+        case res: Matrix => {
+            println("This should not happen.");
+            res;
+        }
+        case err: Error => {
+            println("Caught expected error:");
+            println(err.msg);
+            nil;
+        }
+    };
+
+    return 0;
+}

--- a/demo_program/examples/panic_example.mxs
+++ b/demo_program/examples/panic_example.mxs
@@ -1,0 +1,18 @@
+# Example 5: Panic
+# Demonstrates the panic mechanism for unrecoverable errors.
+
+import std.io as io;
+import std.error.Error as Error;
+static let println = io.println;
+
+func cause_panic() -> nil {
+    println("About to cause an unrecoverable error...");
+    raise Error("FatalError", msg="System integrity compromised.", panic=True);
+    println("This line will never be reached.");
+}
+
+func main() -> int {
+    # Uncomment the following line to see panic in action.
+    # cause_panic();
+    return 0;
+}

--- a/demo_program/examples/static_fib.mxs
+++ b/demo_program/examples/static_fib.mxs
@@ -1,0 +1,19 @@
+# Example 2: Static Deterministic Fibonacci
+# Demonstrates @@static_deterministic, recursion and compile-time evaluation.
+
+import std.io as io;
+static let println = io.println;
+
+@@static_deterministic
+func fib(n: int) -> int {
+    if n <= 1 {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+func main() -> int {
+    let fib_10 = fib(10);
+    println(fib_10);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- split original example script into dedicated sample files
- add README describing each example
- link to new examples in the main README

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686158307b68832192727551c35e989f