### PR TITLE
Extend IO primitives and tests

### DIFF
--- a/demo_program/example/file_io.mxs
+++ b/demo_program/example/file_io.mxs
@@ -1,0 +1,26 @@
+# File: example/file_io.mxs
+# Demonstrates basic file operations and standard stream usage in MxScript.
+
+import std.io as io;
+
+func main() -> int {
+    # Write to stdout
+    io.println("Hello, stdout!");
+
+    # Write directly to stderr
+    io.write_file(2, "This goes to stderr\n");
+
+    # Open a file for writing (flags 577 = O_WRONLY|O_CREAT|O_TRUNC,
+    # mode 438 = 0o666)
+    let fd = io.open_file("demo_output.txt", 577, 438);
+    io.write_file(fd, "File contents\n");
+    io.close_file(fd);
+
+    # Reading from stdin requires a byte buffer. The following is a
+    # conceptual example; dynamic arrays are not yet implemented.
+    # let mut buf: [byte; 128];
+    # let read = io.readline(buf, 128);
+    # io.write_file(1, buf, read);  # Echo back to stdout
+
+    return 0;
+}

--- a/demo_program/std/io.mxs
+++ b/demo_program/std/io.mxs
@@ -2,15 +2,42 @@
     Module: std.io
 #!
 
-@@foreign(c_name="print")
-func __internal_print(s: string) -> int;
+@@foreign(c_name="write")
+func __internal_write(fd: int, buf: string, len: int) -> int;
+@@foreign(c_name="read")
+func __internal_read(fd: int, buf: byte*, len: int) -> int;
+@@foreign(c_name="open")
+func __internal_open(path: string, flags: int, mode: int) -> int;
+@@foreign(c_name="close")
+func __internal_close(fd: int) -> int;
 
 public func print(s: string) -> nil {
-    __internal_print(s);
+    __internal_write(1, s, 1000);
 }
 
 public func println(s: string) -> nil {
-    __internal_print(s);
-    __internal_print("\n");
+    __internal_write(1, s, 1000);
+    __internal_write(1, "
+", 1);
+}
+
+public func readline(buf: byte*, len: int) -> int {
+    return __internal_read(0, buf, len);
+}
+
+public func open_file(path: string, flags: int, mode: int) -> int {
+    return __internal_open(path, flags, mode);
+}
+
+public func read_file(fd: int, buf: byte*, len: int) -> int {
+    return __internal_read(fd, buf, len);
+}
+
+public func write_file(fd: int, s: string) -> int {
+    return __internal_write(fd, s, 1000);
+}
+
+public func close_file(fd: int) -> int {
+    return __internal_close(fd);
 }
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from src.lexer import TokenStream, tokenize
@@ -16,7 +17,7 @@ from src.backend import (
 
 
 
-def main(argv: list[str] | None = None) -> None:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="MxScript driver")
     parser.add_argument("source", help="MxScript source file")
     parser.add_argument("--dump-llir", action="store_true", help="print LLVM IR")
@@ -63,9 +64,8 @@ def main(argv: list[str] | None = None) -> None:
     else:
         result = execute_llvm(ir_prog)
 
-    if result is not None:
-        print(result)
+    return int(result) if result is not None else 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -349,6 +349,29 @@ def _ffi_call(c_name: str, args: List[object]) -> int | None:
         else:
             data = bytes(buf)
         return os.write(fd, data)
+    if c_name == "read":
+        import os
+
+        fd = int(args[0])
+        buf = args[1]
+        count = int(args[2])
+        data = os.read(fd, count)
+        if isinstance(buf, bytearray):
+            buf[: len(data)] = data
+        return len(data)
+    if c_name == "open":
+        import os
+
+        path = str(args[0])
+        flags = int(args[1])
+        mode = int(args[2])
+        return os.open(path, flags, mode)
+    if c_name == "close":
+        import os
+
+        fd = int(args[0])
+        os.close(fd)
+        return 0
     if c_name == "print":
         print(*args)
         return 0

--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -325,7 +325,11 @@ class Parser:
         while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '.':
             self.stream.next()
             parts.append(self.stream.expect('IDENTIFIER').value)
-        return '.'.join(parts)
+        typ = '.'.join(parts)
+        while self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '*':
+            self.stream.next()
+            typ += '*'
+        return typ
 
     def parse_block(self) -> Block:
         self.stream.expect('OPERATOR', '{')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,3 +50,25 @@ def test_backend_return_statement():
     result = compile_and_run(src)
     assert result == 1
 
+
+def test_print_functions(capfd):
+    compile_and_run('import std.io as io; io.print("foo"); io.println("bar");')
+    captured = capfd.readouterr()
+    assert captured.out == "foobar\n"
+
+
+def test_file_operations(tmp_path):
+    path = tmp_path / "out.txt"
+    src = (
+        f'import std.io as io;\n'
+        f'func main() -> int {{\n'
+        f'    let fd = io.open_file("{path}", 577, 438);\n'
+        f'    io.write_file(fd, "hello");\n'
+        f'    io.close_file(fd);\n'
+        f'    return 0;\n'
+        f'}}'
+    )
+    result = compile_and_run(src)
+    assert result == 0
+    assert path.read_text() == "hello"
+


### PR DESCRIPTION
## Summary
- add foreign function declarations for low-level IO primitives
- reimplement `std.io` printing based on `write`
- add simple file helper functions in `std.io`
- extend interpreter FFI handler for read/open/close
- allow pointer types in parser
- exit via `sys.exit` in the CLI
- test new print output and basic file IO
- **add demo example file for file IO usage**

## Testing
- `ruff check src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686155acd7cc832184672cbd7e851a34