### PR TITLE
Update module lookup paths

### DIFF
--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -91,7 +91,7 @@ class ProgramIR:
 def load_module_ast(module: str, search_paths: List[str | Path] | None = None) -> Program:
     """Locate ``module`` and parse it into an AST."""
     if search_paths is None:
-        search_paths = [Path("demo_program")]
+        search_paths = [Path("demo_program/examples"), Path("demo_program")]
     rel = Path(module.replace(".", "/") + ".mxs")
     for base in search_paths:
         path = Path(base) / rel
@@ -121,7 +121,7 @@ def compile_program(
     if module_cache is None:
         module_cache = {}
     if search_paths is None:
-        search_paths = [Path("demo_program")]
+        search_paths = [Path("demo_program/examples"), Path("demo_program")]
     has_main = False
     for stmt in prog.statements:
         if isinstance(stmt, (FuncDef, FunctionDecl)):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -37,7 +37,7 @@ def test_backend_addition():
 
 
 def test_backend_import_hello_world():
-    ir = compile_and_run_file(Path("demo_program/hello_world.mxs"))
+    ir = compile_and_run_file(Path("demo_program/examples/hello_world.mxs"))
     assert "io.println" in ir.functions
 
 def test_auto_main_call():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,6 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-import pytest
-
 import main
 
 
@@ -12,6 +10,5 @@ def test_driver_exit(tmp_path):
     src = "func main() -> int { return 5; }"
     path = tmp_path / "prog.mxs"
     path.write_text(src)
-    with pytest.raises(SystemExit) as exc:
-        main.main([str(path)])
-    assert exc.value.code == 5
+    result = main.main([str(path)])
+    assert result == 5


### PR DESCRIPTION
## Summary
- make `load_module_ast` and `compile_program` look in `demo_program/examples`
- update tests to match file locations and new `main.main` behaviour

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68615d71a1108321a73659b8fdbc3a54