### PR TITLE
Fix hello world example path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ The repository contains a minimal driver which wires all stages together so you
 can parse and execute `.mxs` files:
 
 ```bash
-python main.py demo_program/hello_world.mxs
+python main.py demo_program/examples/hello_world.mxs
 ```
 
 Additional examples are located in `demo_program/examples`. Each file focuses on

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -37,7 +37,7 @@ def test_backend_addition():
 
 
 def test_backend_import_hello_world():
-    ir = compile_and_run_file(Path("demo_program/hello_world.mxs"))
+    ir = compile_and_run_file(Path("demo_program/examples/hello_world.mxs"))
     assert "io.println" in ir.functions
 
 def test_auto_main_call():


### PR DESCRIPTION
## Summary
- update quick-start example to `demo_program/examples/hello_world.mxs`
- update unit tests for the new path

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: Undefined function `println` etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68615d72ed648321b0fd747becffb664