### PR TITLE
Add configurable search path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,12 @@ python main.py demo_program/examples/generic_swap.mxs
 
 To execute using the LLVM backend, pass `--compile-mode llvm`.
 
+### Module search path
+
+Modules are loaded from `demo_program/examples/std` by default. Additional
+directories can be provided via the `MXSCRIPT_PATH` environment variable or the
+`-I/--search-path` command-line flag.
+
 ## Development
 
 Tests can be run with `pytest` and code style is enforced with `ruff`:

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-import sys
 
 from src.lexer import TokenStream, tokenize
 from src.syntax_parser import Parser, dump_ast
@@ -14,6 +13,7 @@ from src.backend import (
     execute_llvm,
     optimize,
     to_llvm_ir,
+    build_search_paths,
 )
 
 
@@ -33,6 +33,13 @@ def main(argv: list[str] | None = None) -> int:
         "-O", "--optimization", type=int, default=0, help="optimization level"
     )
     parser.add_argument("--dump-ast", action="store_true", help="print parsed AST")
+    parser.add_argument(
+        "-I",
+        "--search-path",
+        action="append",
+        dest="search_paths",
+        help="additional module search path",
+    )
 
     args = parser.parse_args(argv)
 
@@ -49,7 +56,8 @@ def main(argv: list[str] | None = None) -> int:
     sema = SemanticAnalyzer()
     sema.analyze(ast)
 
-    ir_prog = compile_program(ast)
+    search_paths = build_search_paths(args.search_paths)
+    ir_prog = compile_program(ast, search_paths=search_paths)
     if args.optimization > 0:
         ir_prog = optimize(ir_prog)
 

--- a/src/backend/__init__.py
+++ b/src/backend/__init__.py
@@ -13,6 +13,7 @@ from .llir import (
     optimize,
     to_llvm_ir,
     execute_llvm,
+    build_search_paths,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "execute",
     "to_llvm_ir",
     "execute_llvm",
+    "build_search_paths",
 ]


### PR DESCRIPTION
## Summary
- add `build_search_paths` helper and env var lookup
- support `--search-path` CLI flag
- default stdlib lookup in `demo_program/examples/std`
- document module search path configuration

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68629ea25f608321ad0ed7bb7956c3ed