### PR TITLE
Support static alias declarations

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -72,3 +72,18 @@ def test_file_operations(tmp_path):
     assert result == 0
     assert path.read_text() == "hello"
 
+
+def test_static_alias_println(capfd):
+    src = (
+        'import std.io as io;\n'
+        'static let println = io.println;\n'
+        'func main() -> int {\n'
+        '    println("hi");\n'
+        '    return 0;\n'
+        '}'
+    )
+    result = compile_and_run(src)
+    captured = capfd.readouterr()
+    assert captured.out == "hi\n"
+    assert result == 0
+

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -7,6 +7,7 @@ from src.lexer import TokenStream, tokenize
 from src.syntax_parser import Parser
 from src.semantic_analyzer import SemanticAnalyzer
 from src.backend import compile_program, optimize, execute_llvm
+from src.backend import to_llvm_ir
 
 
 def compile_and_run(src: str) -> int:
@@ -18,6 +19,15 @@ def compile_and_run(src: str) -> int:
     return execute_llvm(ir_prog)
 
 
+def compile_to_ir(src: str) -> str:
+    tokens = tokenize(src)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+    SemanticAnalyzer().analyze(ast)
+    ir_prog = optimize(compile_program(ast))
+    return to_llvm_ir(ir_prog)
+
+
 def test_llvm_backend_addition():
     result = compile_and_run("let x = 1 + 2; x + 3;")
     assert result == 6
@@ -27,3 +37,13 @@ def test_llvm_return_statement():
     src = "func foo() { return 1; 2; } foo();"
     result = compile_and_run(src)
     assert result == 1
+
+
+def test_llvm_static_alias_println():
+    src = (
+        'import std.io as io;\n'
+        'static let println = io.println;\n'
+        'println("hi");'
+    )
+    ir_text = compile_to_ir(src)
+    assert "io.println" in ir_text


### PR DESCRIPTION
## Summary
- track alias mappings in `compile_program`
- resolve identifiers and calls with alias map during IR generation
- skip bytecode emission for static aliases
- allow LLVM IR generation for string constants
- test static alias with interpreter and LLVM backends

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68629ea016388321a6841cc9c72007ee