### PR TITLE
Fix static imports and LLVM test helper

### DIFF
--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -178,6 +178,11 @@ def compile_program(
                         new_code.append(instr)
                 functions[new_name] = Function(new_name, func.params, new_code)
             foreign_functions.update(mod_ir.foreign_functions)
+            for instr in mod_ir.code:
+                if isinstance(instr, Call) and instr.name in rename_map:
+                    code.append(Call(rename_map[instr.name], instr.argc))
+                else:
+                    code.append(instr)
             continue
         elif isinstance(stmt, BindingStmt) and stmt.is_static and isinstance(stmt.value, Identifier):
             target = stmt.value.name
@@ -467,7 +472,6 @@ def to_llvm_ir(program: ProgramIR) -> str:
                     ptr = builder.gep(gvar, [ir.Constant(int_t, 0), ir.Constant(int_t, 0)])
                     stack.append(builder.ptrtoint(ptr, int_t))
                     string_idx += 1
-                    stack.append(ir.Constant(int_t, 0))
                 else:
                     stack.append(ir.Constant(int_t, instr.value))
             elif isinstance(instr, Load):

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -23,6 +23,11 @@ def compile_and_run(src: str) -> int:
 
 def compile_to_ir(src: str) -> str:
     tokens = tokenize(src)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+    SemanticAnalyzer().analyze(ast)
+    ir_prog = optimize(compile_program(ast))
+    return to_llvm_ir(ir_prog)
 
 def compile_and_run_file(file_path: Path) -> int:
     source = file_path.read_text()


### PR DESCRIPTION
## Summary
- ensure imported modules run their top-level code so constants like `stdout` are initialized
- stop pushing a zero after string constants in LLVM IR generation
- implement `compile_to_ir` helper for LLVM tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862a35f04e083218ba27de798228c48