### PR TITLE
Add time and random stdlib modules

### DIFF
--- a/demo_program/examples/std/random.mxs
+++ b/demo_program/examples/std/random.mxs
@@ -1,0 +1,10 @@
+!#
+    Module: std.random
+#!
+
+@@foreign(c_name="random")
+func __internal_random() -> int;
+
+public func rand() -> int {
+    return __internal_random();
+}

--- a/demo_program/examples/std/time.mxs
+++ b/demo_program/examples/std/time.mxs
@@ -1,0 +1,10 @@
+!#
+    Module: std.time
+#!
+
+@@foreign(c_name="time")
+func __internal_time() -> int;
+
+public func now() -> int {
+    return __internal_time();
+}

--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -424,6 +424,14 @@ def _ffi_call(c_name: str, args: List[object]) -> int | None:
         fd = int(args[0])
         os.close(fd)
         return 0
+    if c_name == "time":
+        import time as _time
+
+        return int(_time.time())
+    if c_name == "random":
+        import random as _random
+
+        return _random.randint(0, 2**31 - 1)
     if c_name == "print":
         print(*args)
         return 0
@@ -574,7 +582,14 @@ def execute_llvm(program: ProgramIR) -> int:
 
     STUB = CFUNCTYPE(c_longlong, c_longlong, c_longlong, c_longlong)(_stub)
     addr = cast(STUB, c_void_p).value
-    for name in ["__internal_write", "__internal_read", "__internal_open", "__internal_close"]:
+    for name in [
+        "__internal_write",
+        "__internal_read",
+        "__internal_open",
+        "__internal_close",
+        "__internal_time",
+        "__internal_random",
+    ]:
         binding.add_symbol(name, addr)
 
     engine.finalize_object()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -87,3 +87,13 @@ def test_static_alias_println(capfd):
     assert captured.out == "hi\n"
     assert result == 0
 
+
+def test_time_module():
+    result = compile_and_run('import std.time as t; t.now();')
+    assert isinstance(result, int)
+
+
+def test_random_module():
+    result = compile_and_run('import std.random as r; r.rand();')
+    assert isinstance(result, int)
+

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -67,3 +67,10 @@ def test_llvm_hello_world_example():
     assert result == 0
 
 
+def test_llvm_time_random_modules():
+    ir_text = compile_to_ir('import std.time as t; t.now();')
+    assert "__internal_time" in ir_text
+    ir_text = compile_to_ir('import std.random as r; r.rand();')
+    assert "__internal_random" in ir_text
+
+


### PR DESCRIPTION
## Summary
- extend `_ffi_call` with `time` and `random`
- register new FFI symbols in `execute_llvm`
- implement `std.time` and `std.random` wrappers
- test time and random modules with interpreter and LLVM backends

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862a60061108321b2503900670b5281