### PR TITLE
Implement ARC runtime framework

### DIFF
--- a/runtime/arc_runtime.c
+++ b/runtime/arc_runtime.c
@@ -1,0 +1,7 @@
+#include "arc_runtime.h"
+
+void arc_release(ArcObject* obj) {
+    if (obj && --obj->ref_count == 0) {
+        free(obj);
+    }
+}

--- a/runtime/arc_runtime.h
+++ b/runtime/arc_runtime.h
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+    int32_t ref_count;
+    /* Object data follows */
+} ArcObject;
+
+static inline void arc_retain(ArcObject* obj) {
+    if (obj) {
+        ++obj->ref_count;
+    }
+}
+
+void arc_release(ArcObject* obj);

--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -66,6 +66,7 @@ class Load(Instr):
 @dataclass
 class Store(Instr):
     name: str
+    type_name: str | None = None
 
 
 @dataclass
@@ -205,7 +206,7 @@ def compile_program(
 def _compile_stmt(stmt, alias_map: Dict[str, str]) -> List[Instr]:
     if isinstance(stmt, LetStmt):
         code = _compile_expr(stmt.value, alias_map)
-        code.append(Store(stmt.name))
+        code.append(Store(stmt.name, stmt.type_name))
         return code
     if isinstance(stmt, BindingStmt):
         if stmt.is_static and isinstance(stmt.value, Identifier):
@@ -215,7 +216,7 @@ def _compile_stmt(stmt, alias_map: Dict[str, str]) -> List[Instr]:
             alias_map[stmt.name] = target
             return []
         code = _compile_expr(stmt.value, alias_map)
-        code.append(Store(stmt.name))
+        code.append(Store(stmt.name, None))
         return code
     if isinstance(stmt, ImportStmt):
         # Import statements produce no executable code
@@ -438,6 +439,15 @@ def to_llvm_ir(program: ProgramIR) -> str:
     int_t = ir.IntType(64)
     module = ir.Module(name="mxscript")
 
+    # ARC runtime declarations
+    obj_ptr_t = ir.IntType(8).as_pointer()
+    arc_retain_fn = ir.Function(
+        module, ir.FunctionType(ir.VoidType(), [obj_ptr_t]), name="arc_retain"
+    )
+    arc_release_fn = ir.Function(
+        module, ir.FunctionType(ir.VoidType(), [obj_ptr_t]), name="arc_release"
+    )
+
     # Declare all functions first
     llvm_funcs: Dict[str, ir.Function] = {}
 
@@ -451,7 +461,12 @@ def to_llvm_ir(program: ProgramIR) -> str:
 
     string_idx = 0
 
-    def emit_code(builder: ir.IRBuilder, code: List[Instr], vars: Dict[str, ir.AllocaInstr]) -> ir.Value:
+    def emit_code(
+        builder: ir.IRBuilder,
+        code: List[Instr],
+        vars: Dict[str, ir.AllocaInstr],
+        var_types: Dict[str, str | None],
+    ) -> ir.Value:
         nonlocal string_idx
         stack: List[ir.Value] = []
 
@@ -460,6 +475,13 @@ def to_llvm_ir(program: ProgramIR) -> str:
                 vars[name] = builder.alloca(int_t, name=name)
                 builder.store(ir.Constant(int_t, 0), vars[name])
             return vars[name]
+
+        def release_all() -> None:
+            for n, ptr in vars.items():
+                typ = var_types.get(n)
+                if typ and (typ == "object" or typ.endswith("*")):
+                    val = builder.load(ptr)
+                    builder.call(arc_release_fn, [builder.inttoptr(val, obj_ptr_t)])
 
         for instr in code:
             if isinstance(instr, Const):
@@ -479,7 +501,19 @@ def to_llvm_ir(program: ProgramIR) -> str:
             elif isinstance(instr, Load):
                 stack.append(builder.load(get_var(instr.name)))
             elif isinstance(instr, Store):
-                builder.store(stack.pop(), get_var(instr.name))
+                val = stack.pop()
+                ptr = get_var(instr.name)
+                if instr.type_name:
+                    var_types[instr.name] = instr.type_name
+                if instr.type_name and (
+                    instr.type_name == "object" or instr.type_name.endswith("*")
+                ):
+                    old_val = builder.load(ptr)
+                    builder.call(
+                        arc_release_fn, [builder.inttoptr(old_val, obj_ptr_t)]
+                    )
+                    builder.call(arc_retain_fn, [builder.inttoptr(val, obj_ptr_t)])
+                builder.store(val, ptr)
             elif isinstance(instr, BinOpInstr):
                 b = stack.pop()
                 a = stack.pop()
@@ -515,6 +549,7 @@ def to_llvm_ir(program: ProgramIR) -> str:
                 stack.append(builder.call(callee, args))
             elif isinstance(instr, Return):
                 ret_val = stack.pop() if stack else ir.Constant(int_t, 0)
+                release_all()
                 builder.ret(ret_val)
                 return None
             elif isinstance(instr, Pop):
@@ -523,6 +558,7 @@ def to_llvm_ir(program: ProgramIR) -> str:
             else:
                 raise RuntimeError(f"Unknown instruction {instr}")
 
+        release_all()
         return stack[-1] if stack else ir.Constant(int_t, 0)
 
     # Build function bodies
@@ -532,12 +568,14 @@ def to_llvm_ir(program: ProgramIR) -> str:
         builder = ir.IRBuilder(block)
 
         vars: Dict[str, ir.AllocaInstr] = {}
+        var_types: Dict[str, str | None] = {}
         for arg, name in zip(func.args, func_ir.params):
             ptr = builder.alloca(int_t, name=name)
             builder.store(arg, ptr)
             vars[name] = ptr
+            var_types[name] = None
 
-        ret_val = emit_code(builder, func_ir.code, vars)
+        ret_val = emit_code(builder, func_ir.code, vars, var_types)
         if ret_val is not None:
             builder.ret(ret_val)
 
@@ -546,7 +584,7 @@ def to_llvm_ir(program: ProgramIR) -> str:
     start_fn = ir.Function(module, start_ty, name="__start")
     block = start_fn.append_basic_block("entry")
     builder = ir.IRBuilder(block)
-    ret = emit_code(builder, program.code, {})
+    ret = emit_code(builder, program.code, {}, {})
     if ret is not None:
         builder.ret(ret)
 


### PR DESCRIPTION
## Summary
- add a tiny C runtime with `arc_retain`/`arc_release`
- extend `Store` instruction with a `type_name` for tracking reference types
- declare ARC runtime functions in the LLVM backend
- add hooks for retain/release when storing ARC managed values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862a6aa3b3883218e42a7f3b30ce612