### PR TITLE
Add LLVM FFI test and runtime bindings

### DIFF
--- a/demo_program/examples/std/random.mxs
+++ b/demo_program/examples/std/random.mxs
@@ -1,0 +1,6 @@
+!#
+    Module: std.random
+#!
+
+@@foreign(c_name="random_rand")
+func rand() -> int;

--- a/demo_program/examples/std/time.mxs
+++ b/demo_program/examples/std/time.mxs
@@ -1,0 +1,6 @@
+!#
+    Module: std.time
+#!
+
+@@foreign(c_name="time_now")
+func now() -> int;

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -67,3 +67,9 @@ def test_llvm_hello_world_example():
     assert result == 0
 
 
+
+def test_llvm_ffi_time_random():
+    res_time = compile_and_run('import std.time as time; time.now();')
+    assert isinstance(res_time, int)
+    res_rand = compile_and_run('import std.random as random; random.rand();')
+    assert isinstance(res_rand, int)


### PR DESCRIPTION
## Summary
- support `std.time` and `std.random` modules through FFI
- register time and random helpers when executing LLVM code
- rename foreign calls when importing modules
- test LLVM backend with `std.time.now()` and `std.random.rand()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862a8432ac483219fe73bebaa5e1c25