### PR TITLE
Implement destructor codegen

### DIFF
--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -111,3 +111,23 @@ def test_llvm_file_operations(tmp_path):
     result = compile_and_run(src)
     assert result == 0
     assert path.read_text() == "hello"
+
+
+def test_llvm_destructor_call(capfd):
+    src = (
+        'import std.io as io;\n'
+        'struct Loud {\n'
+        '    func ~Loud() {\n'
+        '        io.println("Object destroyed!");\n'
+        '    }\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    io.println("Creating object...");\n'
+        '    let obj: Loud = 0;\n'
+        '    io.println("Object created. Exiting main...");\n'
+        '    return 0;\n'
+        '}'
+    )
+    compile_and_run(src)
+    captured = capfd.readouterr()
+    assert "Object destroyed!" in captured.out

--- a/tests/test_scoped_destruction.py
+++ b/tests/test_scoped_destruction.py
@@ -27,10 +27,8 @@ def test_destructor_call_injection():
     analyzer = SemanticAnalyzer()
     analyzer.analyze(ast)
 
-    # remove struct definition before compilation
-    ast.statements = [s for s in ast.statements if not isinstance(s, StructDef)]
-
     ir = compile_program(ast, analyzer.type_registry)
+    assert "File_destructor" in ir.functions
 
     code = ir.functions["main"].code
     assert isinstance(code[-1], DestructorCall)


### PR DESCRIPTION
## Summary
- compile struct destructors into ProgramIR functions
- emit destructor calls in LLVM backend
- track variable type metadata for calling destructors
- test RAII behavior via LLVM backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863553b454883218a3206e2e6d1b1fb