### PR TITLE
Add custom error reporting system

### DIFF
--- a/src/errors.py
+++ b/src/errors.py
@@ -1,11 +1,39 @@
 from dataclasses import dataclass
+from typing import Optional
 
-from .lexer import Token
 
 @dataclass
-class SyntaxErrorWithPos(Exception):
-    message: str
-    token: Token
+class SourceLocation:
+    """Represents a position within a source file."""
 
-    def __str__(self) -> str:  # pragma: no cover - simple formatting
-        return f"{self.message} at line {self.token.line}, column {self.token.col}"
+    filename: str
+    line: int
+    column: int
+    source_line: str = ""
+
+
+class CompilerError(Exception):
+    """Base class for all controlled compiler errors."""
+
+    def __init__(self, message: str, location: Optional[SourceLocation] = None) -> None:
+        self.message = message
+        self.location = location
+        super().__init__(self.message)
+
+
+class SyntaxError(CompilerError):
+    """Error raised when the parser encounters invalid syntax."""
+
+    pass
+
+
+class SemanticError(CompilerError):
+    """Error raised during semantic analysis."""
+
+    pass
+
+
+class NameError(SemanticError):
+    """Semantic error for undefined or duplicate names."""
+
+    pass

--- a/src/lexer/token_stream.py
+++ b/src/lexer/token_stream.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
 from .Token import Token
-from ..errors import SyntaxErrorWithPos
+from ..errors import SyntaxError, SourceLocation
 
 
 @dataclass
@@ -43,10 +43,12 @@ class TokenStream:
     def expect(self, tk_type: str, value: Optional[str] = None) -> Token:
         token = self.next()
         if token is None:
-            raise SyntaxErrorWithPos(f"Expected {tk_type}", self.tokens[-1])
+            loc = SourceLocation("<tokens>", self.tokens[-1].line, self.tokens[-1].col, "")
+            raise SyntaxError(f"Expected {tk_type}", loc)
         if token.tk_type != tk_type or (value is not None and token.value != value):
             msg = f"Expected {tk_type} '{value}'" if value else f"Expected {tk_type}"
-            raise SyntaxErrorWithPos(msg, token)
+            loc = SourceLocation("<tokens>", token.line, token.col, "")
+            raise SyntaxError(msg, loc)
         return token
 
     def __iter__(self) -> Iterable[Token]:

--- a/src/semantic_analyzer/__init__.py
+++ b/src/semantic_analyzer/__init__.py
@@ -1,4 +1,5 @@
-from .analyzer import SemanticAnalyzer, SemanticError
+from ..errors import SemanticError, NameError
+from .analyzer import SemanticAnalyzer
 from .types import TypeInfo
 
-__all__ = ["SemanticAnalyzer", "SemanticError", "TypeInfo"]
+__all__ = ["SemanticAnalyzer", "SemanticError", "NameError", "TypeInfo"]

--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Set
 
 from ..backend.llir import load_module_ast
 from .types import TypeInfo
+from ..errors import SemanticError, SourceLocation, NameError
 
 from ..syntax_parser.ast import (
     BinaryOp,
@@ -31,10 +32,7 @@ from ..syntax_parser.ast import (
     Expression,
     UnaryOp,
 )
-
-
-class SemanticError(Exception):
-    """Raised when semantic analysis fails."""
+from ..lexer.Token import Token
 
 
 @dataclass
@@ -44,8 +42,12 @@ class SemanticAnalyzer:
     variables_stack: List[Set[str]] | None = None
     functions: Set[str] | None = None
     type_registry: Dict[str, TypeInfo] | None = None
+    filename: str = "<stdin>"
+    source_lines: List[str] = field(default_factory=list)
 
-    def analyze(self, program: Program) -> None:
+    def analyze(self, program: Program, *, source: str = "", filename: str = "<stdin>") -> None:
+        self.filename = filename
+        self.source_lines = source.splitlines()
         self.functions = set()
         self._collect_functions(program)
         self.type_registry = {}
@@ -78,6 +80,14 @@ class SemanticAnalyzer:
             if name in scope:
                 return True
         return False
+
+    def _get_location(self, token: Token | None) -> SourceLocation | None:
+        if token is None:
+            return None
+        line = token.line
+        column = token.col
+        source_line = self.source_lines[line - 1] if 0 <= line - 1 < len(self.source_lines) else ""
+        return SourceLocation(self.filename, line, column, source_line)
 
     def _visit_statement(self, stmt: Statement) -> None:
         if isinstance(stmt, (LetStmt, BindingStmt)):
@@ -127,12 +137,18 @@ class SemanticAnalyzer:
         elif isinstance(stmt, StructDef):
             self._visit_struct_def(stmt)
         else:
-            raise SemanticError(f"Unsupported statement {type(stmt).__name__}")
+            raise SemanticError(
+                f"Unsupported statement {type(stmt).__name__}",
+                self._get_location(stmt.loc),
+            )
 
     def _visit_struct_def(self, struct: StructDef) -> None:
         assert self.type_registry is not None
         if struct.name in self.type_registry:
-            raise SemanticError(f"Type '{struct.name}' is already defined.")
+            raise SemanticError(
+                f"Type '{struct.name}' is already defined.",
+                self._get_location(struct.loc),
+            )
 
         type_info = TypeInfo(name=struct.name)
         self.type_registry[struct.name] = type_info
@@ -156,7 +172,10 @@ class SemanticAnalyzer:
         if isinstance(expr, Identifier):
             name = expr.name.split('.')[0]
             if not self._is_defined(name):
-                raise SemanticError(f"Undefined variable '{expr.name}'")
+                raise NameError(
+                    f"Undefined variable '{expr.name}'",
+                    self._get_location(expr.loc),
+                )
         elif isinstance(expr, Integer):
             pass
         elif isinstance(expr, String):
@@ -181,8 +200,14 @@ class SemanticAnalyzer:
         elif isinstance(expr, FunctionCall):
             # Check that the function exists
             if '.' not in expr.name and self.functions is not None and expr.name not in self.functions:
-                raise SemanticError(f"Undefined function '{expr.name}'")
+                raise NameError(
+                    f"Undefined function '{expr.name}'",
+                    self._get_location(expr.loc),
+                )
             for arg in expr.args:
                 self._visit_expression(arg)
         else:
-            raise SemanticError(f"Unsupported expression {type(expr).__name__}")
+            raise SemanticError(
+                f"Unsupported expression {type(expr).__name__}",
+                self._get_location(expr.loc),
+            )

--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
+
+from ..lexer.Token import Token
 
 
+@dataclass(kw_only=True)
 class Node:
     """Base class for all AST nodes."""
+
+    loc: Optional[Token] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- define new error classes with source location information
- attach location tokens to all AST nodes
- update parser to record positions and raise `SyntaxError`
- extend semantic analyzer to raise detailed `SemanticError` and `NameError`
- add centralized error printing in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68635a265ea083219698bd82734ac2ae