### PR TITLE
Add destructor execution to LLIR interpreter

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -106,3 +106,41 @@ def test_constructor_call(capfd):
     captured = capfd.readouterr()
     assert "ctor" in captured.out
 
+
+def test_destructor_call(capfd):
+    src = (
+        'import std.io as io;\n'
+        'struct Loud {\n'
+        '    func ~Loud() {\n'
+        '        io.println("Object destroyed!");\n'
+        '    }\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    io.println("Creating object...");\n'
+        '    let obj: Loud = 0;\n'
+        '    io.println("Object created. Exiting main...");\n'
+        '    return 0;\n'
+        '}'
+    )
+    compile_and_run(src)
+    captured = capfd.readouterr()
+    assert "Object destroyed!" in captured.out
+
+
+def test_constructor_and_destructor_call(capfd):
+    src = (
+        'import std.io as io;\n'
+        'struct Box {\n'
+        '    func Box() { io.println("ctor"); }\n'
+        '    func ~Box() { io.println("dtor"); }\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    let b: Box = Box();\n'
+        '    return 0;\n'
+        '}'
+    )
+    compile_and_run(src)
+    captured = capfd.readouterr()
+    assert "ctor" in captured.out
+    assert "dtor" in captured.out
+


### PR DESCRIPTION
## Summary
- track variable metadata when storing values in the interpreter
- invoke struct destructors when `DestructorCall` instructions execute
- add interpreter tests for destructor handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686362b06ef883218af587bc6044efc1