### PR TITLE
Handle inferred destructor bindings

### DIFF
--- a/tests/test_scoped_destruction.py
+++ b/tests/test_scoped_destruction.py
@@ -34,3 +34,28 @@ def test_destructor_call_injection():
     assert isinstance(code[-1], DestructorCall)
     assert code[-1].name == "f"
 
+
+def test_destructor_call_injection_inferred_type():
+    source = """
+    struct File {
+        func File() {}
+        func ~File() {}
+    }
+    func main() {
+        let f = File();
+    }
+    """
+    tokens = tokenize(source)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+
+    analyzer = SemanticAnalyzer()
+    analyzer.analyze(ast)
+
+    ir = compile_program(ast, analyzer.type_registry)
+    assert "File_destructor" in ir.functions
+
+    code = ir.functions["main"].code
+    assert isinstance(code[-1], DestructorCall)
+    assert code[-1].name == "f"
+


### PR DESCRIPTION
## Summary
- mark `let` bindings for destructor when struct constructor is used without explicit type
- preserve inferred type in symbol table
- test destructor injection for inferred struct type

## Testing
- `pytest tests/test_scoped_destruction.py::test_destructor_call_injection_inferred_type -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686362b3e0d883218f907d562ef79206