### PR TITLE
Add ARC runtime implementation and build integration

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,50 @@
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+
+from src.lexer import TokenStream, tokenize
+from src.syntax_parser import Parser
+from src.semantic_analyzer import SemanticAnalyzer
+from src.backend import compile_program, optimize, to_llvm_ir, build_search_paths
+
+
+def compile_source(source: str, filename: str, opt_level: int, search_paths):
+    tokens = tokenize(source)
+    stream = TokenStream(tokens)
+    parser = Parser(stream, source=source, filename=filename)
+    ast = parser.parse()
+    analyzer = SemanticAnalyzer()
+    analyzer.analyze(ast, source=source, filename=filename)
+    ir_prog = compile_program(ast, search_paths=build_search_paths(search_paths))
+    if opt_level > 0:
+        ir_prog = optimize(ir_prog)
+    return to_llvm_ir(ir_prog)
+
+
+def build_executable(source_file: Path, output: Path, opt_level: int = 0, search_paths=None):
+    llvm_ir = compile_source(source_file.read_text(), str(source_file), opt_level, search_paths)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        ll_path = tmpdir_path / "out.ll"
+        ll_path.write_text(llvm_ir)
+        obj_path = tmpdir_path / "out.o"
+        subprocess.run(["llc", ll_path, "-filetype=obj", "-o", obj_path], check=True)
+        runtime_obj = tmpdir_path / "arc_runtime.o"
+        subprocess.run(["clang", "-c", "runtime/arc_runtime.c", "-o", runtime_obj], check=True)
+        subprocess.run(["clang", obj_path, runtime_obj, "-o", output], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build MxScript program")
+    parser.add_argument("source")
+    parser.add_argument("-o", "--output", default="a.out")
+    parser.add_argument("-O", "--opt", type=int, default=0)
+    parser.add_argument("-I", "--search-path", action="append", dest="search_paths")
+    args = parser.parse_args()
+
+    build_executable(Path(args.source), Path(args.output), args.opt, args.search_paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/arc_runtime.c
+++ b/runtime/arc_runtime.c
@@ -1,7 +1,29 @@
 #include "arc_runtime.h"
 
-void arc_release(ArcObject* obj) {
-    if (obj && --obj->ref_count == 0) {
-        free(obj);
+void* arc_alloc(size_t size) {
+    long long* base = malloc(sizeof(long long) + size);
+    if (!base) {
+        return NULL;
+    }
+    *base = 1;
+    return (void*)(base + 1);
+}
+
+void* arc_retain(void* ptr) {
+    if (!ptr) {
+        return NULL;
+    }
+    long long* base = ((long long*)ptr) - 1;
+    ++(*base);
+    return ptr;
+}
+
+void arc_release(void* ptr) {
+    if (!ptr) {
+        return;
+    }
+    long long* base = ((long long*)ptr) - 1;
+    if (--(*base) == 0) {
+        free(base);
     }
 }

--- a/runtime/arc_runtime.h
+++ b/runtime/arc_runtime.h
@@ -1,15 +1,10 @@
-#include <stdint.h>
+#ifndef ARC_RUNTIME_H
+#define ARC_RUNTIME_H
+
 #include <stdlib.h>
 
-typedef struct {
-    int32_t ref_count;
-    /* Object data follows */
-} ArcObject;
+void* arc_alloc(size_t size);
+void* arc_retain(void* ptr);
+void arc_release(void* ptr);
 
-static inline void arc_retain(ArcObject* obj) {
-    if (obj) {
-        ++obj->ref_count;
-    }
-}
-
-void arc_release(ArcObject* obj);
+#endif /* ARC_RUNTIME_H */

--- a/src/backend/ffi.py
+++ b/src/backend/ffi.py
@@ -16,6 +16,10 @@ LIBC_FUNCTIONS: Dict[str, dict] = {
     'close': {'ret': int32, 'args': [int32]},
     'malloc': {'ret': char_ptr, 'args': [int64]},
     'free': {'ret': ir.VoidType(), 'args': [char_ptr]},
+    # ARC runtime
+    'arc_alloc': {'ret': char_ptr, 'args': [int64]},
+    'arc_retain': {'ret': char_ptr, 'args': [char_ptr]},
+    'arc_release': {'ret': ir.VoidType(), 'args': [char_ptr]},
     # Aliases used in the current standard library
     # MxScript convenience wrappers
     # time_now() -> time(NULL)


### PR DESCRIPTION
## Summary
- implement ARC runtime functions arc_alloc, arc_retain, arc_release
- declare ARC runtime functions in FFI manager
- add simple build script that compiles and links the ARC runtime

## Testing
- `ruff check src/backend/ffi.py build.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68636a6fe6708321af370a6757e6210d