### PR TITLE
Integrate ARC into object allocation

### DIFF
--- a/tests/test_arc_runtime.py
+++ b/tests/test_arc_runtime.py
@@ -49,3 +49,19 @@ def test_arc_runtime_calls_emit_correct_ir():
     assert 'call i8* @"arc_retain"' in ir
     assert 'call void @"arc_release"' in ir
 
+
+def test_struct_allocation_uses_arc_runtime():
+    src = (
+        'struct Point {\n'
+        '    func Point() {}\n'
+        '    func ~Point() {}\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    let p: Point = Point();\n'
+        '    return 0;\n'
+        '}\n'
+    )
+    ir = compile_to_ir(src)
+    assert 'call i8* @"arc_alloc"' in ir
+    assert 'call void @"arc_release"' in ir
+


### PR DESCRIPTION
## Summary
- switch LLVM `Alloc` handling to use `arc_alloc`
- call `arc_release` whenever an object destructor runs
- add regression test ensuring struct allocation emits ARC calls

## Testing
- `ruff check src/backend/llvm/generator.py tests/test_arc_runtime.py`
- `ruff check src tests` *(fails: F401 etc.)*
- `pytest -q` *(fails: segmentation fault during LLVM tests)*

------
https://chatgpt.com/codex/tasks/task_b_68636d99f76883219a3a5b0fd5d25952