### PR TITLE
Add ARC retain on variable assignment

### DIFF
--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -282,6 +282,16 @@ def _compile_stmt(
         if stmt.value is not None:
             code.extend(_compile_expr(stmt.value, alias_map, symtab, type_registry))
 
+        # If assigning from another ARC-managed variable, retain the value
+        if isinstance(stmt.value, Identifier) and type_registry is not None:
+            sym = symtab.lookup(stmt.value.name)
+            if (
+                sym is not None
+                and sym.type_name is not None
+                and sym.type_name in type_registry
+            ):
+                code.append(Call("arc_retain", 1))
+
         resolved_type = stmt.type_name
         needs_destruction = False
 

--- a/src/backend/llvm/generator.py
+++ b/src/backend/llvm/generator.py
@@ -174,7 +174,10 @@ class LLVMGenerator:
                 args = [stack.pop() for _ in range(instr.argc)][::-1]
                 callee = self.functions.get(instr.name)
                 if callee is None:
-                    callee = self.ctx.module.get_global(instr.name)
+                    try:
+                        callee = self.ctx.module.get_global(instr.name)
+                    except KeyError:
+                        callee = self.ffi.get_or_declare_function(instr.name)
                 func_ty = callee.function_type
                 cast_args: List[ir.Value] = []
                 for i, arg in enumerate(args):

--- a/tests/test_arc_runtime.py
+++ b/tests/test_arc_runtime.py
@@ -65,3 +65,18 @@ def test_struct_allocation_uses_arc_runtime():
     assert 'call i8* @"arc_alloc"' in ir
     assert 'call void @"arc_release"' in ir
 
+
+def test_arc_retain_on_assignment():
+    src = (
+        'struct Point {\n'
+        '    func Point() {}\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    let p1: Point = Point();\n'
+        '    let p2: Point = p1;\n'
+        '    return 0;\n'
+        '}\n'
+    )
+    ir = compile_to_ir(src)
+    assert 'call i8* @"arc_retain"' in ir
+


### PR DESCRIPTION
## Summary
- insert `arc_retain` when assigning a heap object to a new variable
- fallback to FFI when calls reference unknown functions
- test ARC retain behavior on assignment

## Testing
- `pytest tests/test_backend.py tests/test_arc_runtime.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68637042d8dc8321903583134f07d17e