### PR TITLE
Add ARC release on variable reassignment

### DIFF
--- a/tests/test_arc_runtime.py
+++ b/tests/test_arc_runtime.py
@@ -80,3 +80,17 @@ def test_arc_retain_on_assignment():
     ir = compile_to_ir(src)
     assert 'call i8* @"arc_retain"' in ir
 
+
+def test_arc_release_on_reassignment():
+    src = (
+        'struct Data {\n'
+        '    func Data() {}\n'
+        '}\n'
+        'func main() {\n'
+        '    let d: Data = Data();\n'
+        '    let d: Data = Data();\n'
+        '}\n'
+    )
+    ir = compile_to_ir(src)
+    assert ir.count('call void @"arc_release"') == 1
+


### PR DESCRIPTION
## Summary
- release previously held ARC-managed value before storing a new one
- test release call injection when a variable is reassigned

## Testing
- `ruff check src/backend/llvm/generator.py`
- `ruff check tests/test_arc_runtime.py`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6863723f1fa88321a028802fd48a4b58