### PR TITLE
Implement ARC retains for function arguments

### DIFF
--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -398,11 +398,27 @@ def _compile_expr(
             code.append(Dup())
             for arg in expr.args:
                 code.extend(_compile_expr(arg, alias_map, symtab, type_registry))
+                if isinstance(arg, Identifier) and type_registry is not None:
+                    sym = symtab.lookup(arg.name)
+                    if (
+                        sym is not None
+                        and sym.type_name is not None
+                        and sym.type_name in type_registry
+                    ):
+                        code.append(Call("arc_retain", 1))
             code.append(Call(f"{expr.name}_constructor", len(expr.args) + 1))
             code.append(Pop())
             return code
         for arg in expr.args:
             code.extend(_compile_expr(arg, alias_map, symtab, type_registry))
+            if isinstance(arg, Identifier) and type_registry is not None:
+                sym = symtab.lookup(arg.name)
+                if (
+                    sym is not None
+                    and sym.type_name is not None
+                    and sym.type_name in type_registry
+                ):
+                    code.append(Call("arc_retain", 1))
         name = expr.name
         while name in alias_map:
             name = alias_map[name]

--- a/tests/test_arc_runtime.py
+++ b/tests/test_arc_runtime.py
@@ -94,3 +94,21 @@ def test_arc_release_on_reassignment():
     ir = compile_to_ir(src)
     assert ir.count('call void @"arc_release"') == 1
 
+
+def test_arc_retain_for_function_args():
+    src = (
+        'struct Token {\n'
+        '    func Token() {}\n'
+        '}\n'
+        'func process_token(t: Token) -> Token {\n'
+        '    return t;\n'
+        '}\n'
+        'func main() -> int {\n'
+        '    let tok1: Token = Token();\n'
+        '    let tok2: Token = process_token(tok1);\n'
+        '    return 0;\n'
+        '}\n'
+    )
+    ir = compile_to_ir(src)
+    assert ir.count('call i8* @"arc_retain"') == 1
+


### PR DESCRIPTION
## Summary
- retain ARC-managed references when passed as function arguments
- add regression test verifying retain on function calls

## Testing
- `pytest tests/test_arc_runtime.py::test_arc_retain_for_function_args -q`
- `pytest tests/test_backend.py::test_backend_addition -q`
- `pytest tests/test_llvm_backend.py::test_llvm_backend_addition -q`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6863743a2d9483219d4059a92c8b818a