### PR TITLE
Improve class access specifier parsing

### DIFF
--- a/src/syntax_parser/parser.py
+++ b/src/syntax_parser/parser.py
@@ -90,9 +90,6 @@ class Parser:
                     'Annotation only supported before functions',
                     self._get_location(next_tok),
                 )
-        if tok.tk_type == 'KEYWORD' and tok.value in ('public', 'private'):
-            self.stream.next()
-            tok = self.stream.peek()
         if tok.tk_type == 'KEYWORD' and tok.value == 'import':
             return self.parse_import()
         if tok.tk_type == 'KEYWORD' and tok.value == 'let':
@@ -369,6 +366,15 @@ class Parser:
             self.stream.peek().tk_type == 'OPERATOR' and self.stream.peek().value == '}'
         ):
             tok = self.stream.peek()
+            if tok.tk_type == 'KEYWORD' and tok.value in ('public', 'private'):
+                # consume access modifier and optional colon
+                self.stream.next()
+                if (
+                    self.stream.peek().tk_type == 'OPERATOR'
+                    and self.stream.peek().value == ':'
+                ):
+                    self.stream.next()
+                continue
             if tok.tk_type == 'KEYWORD' and tok.value == 'let':
                 statements.append(self.parse_field_decl())
             elif (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -253,3 +253,18 @@ def test_parse_class_with_constructor():
     ctor_found = any(isinstance(s, ConstructorDef) for s in struct_def.body.statements)
     assert ctor_found
 
+
+def test_parse_class_with_access_specifiers():
+    source = """
+    class Foo {
+        public:
+        let x: int;
+        private:
+        let y: int;
+    }
+    """
+    tokens = tokenize(source)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+    assert isinstance(ast.statements[0], ClassDef)
+


### PR DESCRIPTION
## Summary
- clean up `parse_statement` to ignore `public` and `private`
- handle access specifiers within `parse_class_def`
- add a parser test covering `public:` and `private:` sections

## Testing
- `pytest tests/test_parser.py::test_parse_class_with_access_specifiers -q`
- `pytest tests/test_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_b_6863895b5cf88321807244441b80d626