### PR TITLE
Fix std::Error template types

### DIFF
--- a/stdlib/std/error.mxs
+++ b/stdlib/std/error.mxs
@@ -13,9 +13,9 @@ public:
 
     Error(msg:string) {}
 
-    Error(msg:string, alternative:T) {}
+    Error(msg:string, alternative: AlternativeType) {}
 
-    Error(msg: string, alternative: T, panic: bool) {}
+    Error(msg: string, alternative: AlternativeType, panic: bool) {}
 
 
 }


### PR DESCRIPTION
## Summary
- correct constructor signatures in `std.error` to use `AlternativeType`

## Testing
- `ruff check src tests` *(fails: unused imports)*
- `pytest -q` *(fails: several parser and backend tests)*
- `python main.py demo_program/examples/matrix_class.mxs` *(fails: Expected OPERATOR ')')*
- `python main.py demo_program/examples/hello_world.mxs` *(fails: Unexpected token KEYWORD)*

------
https://chatgpt.com/codex/tasks/task_b_68638b5fb7fc8321bb868a0242777e65