### PR TITLE
Add method parsing tests

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -254,11 +254,30 @@ def test_parse_class_with_constructor():
     assert ctor_found
 
 
+def test_parse_class_with_method():
+    source = """
+    class Foo {
+        func bar() { let x = 1; }
+    }
+    """
+    tokens = tokenize(source)
+    stream = TokenStream(tokens)
+    ast = Parser(stream).parse()
+
+    struct_def = ast.statements[0]
+    from src.syntax_parser.ast import MethodDef
+    methods = [s for s in struct_def.body.statements if isinstance(s, MethodDef)]
+    assert len(methods) == 1
+    m = methods[0]
+    assert m.name == "bar"
+
+
 
 def test_parse_class_with_access_specifiers():
     source = """
     class Foo {
         public:
+        func bar() {}
         let x: int;
         private:
         let y: int;


### PR DESCRIPTION
## Summary
- fix parser test for access specifiers by adding a method in the example class
- add new test `test_parse_class_with_method`

## Testing
- `ruff check src tests` *(fails: Symbol, Identifier unused etc.)*
- `pytest -q` *(fails: SyntaxError when parsing stdlib modules)*

------
https://chatgpt.com/codex/tasks/task_b_68638b5f31e48321a1c5d0a6fde39a68