### PR TITLE
Fix missing terminators in LLVM output

### DIFF
--- a/src/backend/llvm/generator.py
+++ b/src/backend/llvm/generator.py
@@ -271,6 +271,8 @@ class LLVMGenerator:
         ret = self._emit_code(func_ir.code)
         if ret is not None:
             self.ctx.builder.ret(ret)
+        if not self.ctx.builder.block.is_terminated:
+            self.ctx.builder.ret(ir.Constant(self.ctx.int_t, 0))
         self.ctx.pop_scope()
         self.var_info_stack.pop()
 
@@ -284,4 +286,6 @@ class LLVMGenerator:
         ret = self._emit_code(code)
         if ret is not None:
             self.ctx.builder.ret(ret)
+        if not self.ctx.builder.block.is_terminated:
+            self.ctx.builder.ret(ir.Constant(self.ctx.int_t, 0))
         self.var_info_stack.pop()


### PR DESCRIPTION
## Summary
- add fallback `ret` instructions in LLVM generator so every function ends in a terminator

## Testing
- `python -m py_compile src/backend/llvm/generator.py`
- `pytest tests/test_tokenizer.py -q`
- `pytest tests/test_arc_integration.py::test_complex_member_lifecycle -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6863a6f5ffcc8321b98fd2238310eb33