### PR TITLE
Check for duplicate variables in SemanticAnalyzer

### DIFF
--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -116,10 +116,17 @@ class SemanticAnalyzer:
 
     def _visit_statement(self, stmt: Statement) -> None:
         if isinstance(stmt, (LetStmt, BindingStmt)):
+            if stmt.name in self._current_scope():
+                raise NameError(
+                    f"Variable '{stmt.name}' is already defined.",
+                    self._get_location(stmt.loc),
+                )
             if stmt.value is not None:
                 self._visit_expression(stmt.value)
             is_mut = stmt.is_mut if isinstance(stmt, LetStmt) else False
-            self._current_scope()[stmt.name] = VarInfo(stmt.name, getattr(stmt, 'type_name', None), is_mut)
+            self._current_scope()[stmt.name] = VarInfo(
+                stmt.name, getattr(stmt, "type_name", None), is_mut
+            )
         elif isinstance(stmt, ExprStmt):
             self._visit_expression(stmt.expr)
         elif isinstance(stmt, RaiseStmt):

--- a/tests/test_arc_runtime.py
+++ b/tests/test_arc_runtime.py
@@ -1,11 +1,12 @@
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src.lexer import TokenStream, tokenize
 from src.syntax_parser import Parser
-from src.semantic_analyzer import SemanticAnalyzer
+from src.semantic_analyzer import SemanticAnalyzer, SemanticError
 from src.backend import compile_program, optimize, to_llvm_ir
 from src.backend.ffi import LIBC_FUNCTIONS
 
@@ -91,8 +92,8 @@ def test_arc_release_on_reassignment():
         '    let d: Data = Data();\n'
         '}\n'
     )
-    ir = compile_to_ir(src)
-    assert ir.count('call void @"arc_release"') == 1
+    with pytest.raises(SemanticError):
+        compile_to_ir(src)
 
 
 def test_arc_retain_for_function_args():

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -122,3 +122,14 @@ def test_assignment_to_mutable_ok():
     src = "let mut x = 3; x = 5;"
     analyze(src)
 
+
+def test_duplicate_let_error():
+    src = "let x = 5; let x = 3;"
+    with pytest.raises(SemanticError):
+        analyze(src)
+
+
+def test_shadowing_ok():
+    src = "let x = 1; { let x = 2; }"
+    analyze(src)
+


### PR DESCRIPTION
## Summary
- raise a `NameError` when `LetStmt` or `BindingStmt` redeclares a name in the same scope
- test duplicate definitions and valid shadowing
- adjust ARC runtime test to expect a semantic error after the new rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863ca82ea88832192cb10d4327e62bc