### PR TITLE
Enable loop and conditional control flow in LLVM backend

### DIFF
--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -32,3 +32,39 @@ def test_until_loop_scope():
     result = compile_and_run(src)
     assert result == 5
 
+
+def test_do_until_loop():
+    src = (
+        'func main() -> int {\n'
+        '    let mut x = 0;\n'
+        '    do {\n'
+        '        x = x + 1;\n'
+        '    } until (x == 3);\n'
+        '    return x;\n'
+        '}'
+    )
+    result = compile_and_run(src)
+    assert result == 3
+
+
+def test_loop_break_continue():
+    src = (
+        'func main() -> int {\n'
+        '    let mut i = 0;\n'
+        '    let mut sum = 0;\n'
+        '    loop {\n'
+        '        i = i + 1;\n'
+        '        if i > 5 {\n'
+        '            break;\n'
+        '        }\n'
+        '        if i % 2 == 0 {\n'
+        '            continue;\n'
+        '        }\n'
+        '        sum = sum + i;\n'
+        '    }\n'
+        '    return sum;\n'
+        '}'
+    )
+    result = compile_and_run(src)
+    assert result == 9
+


### PR DESCRIPTION
## Summary
- implement full LLIR generation for `if`, loops, `break` and `continue`
- maintain break/continue target stacks
- allow mutable variables to reuse allocations across nested scopes
- add regression tests covering do-until loops and `continue`

## Testing
- `pytest tests/test_loops.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864c5f4e79883218c1a9ba3e89ca82e