### PR TITLE
Refactor tokenizer module

### DIFF
--- a/src/frontend/tokenization.py
+++ b/src/frontend/tokenization.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import List
+
+from .tokens import TokenType, Token, KEYWORDS, OPERATORS
+
+
+class Tokenizer:
+    """Converts source text into a stream of :class:`Token` objects."""
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+        self.length = len(source)
+        self.index = 0
+        self.line = 1
+        self.col = 1
+
+    # ------------------------------------------------------------------
+    def _peek(self) -> str:
+        return self.source[self.index] if self.index < self.length else ""
+
+    def _advance(self) -> str:
+        ch = self._peek()
+        self.index += 1
+        if ch == "\n":
+            self.line += 1
+            self.col = 1
+        else:
+            self.col += 1
+        return ch
+
+    # ------------------------------------------------------------------
+    def tokenize(self) -> List[Token]:
+        tokens: List[Token] = []
+        while self.index < self.length:
+            ch = self._peek()
+
+            # Skip whitespace
+            if ch in " \t\r":
+                self._advance()
+                continue
+            if ch == "\n":
+                self._advance()
+                continue
+
+            # Single line comment starting with '#'
+            if ch == "#":
+                start_line, start_col = self.line, self.col
+                self._advance()
+                while self.index < self.length and self._peek() != "\n":
+                    self._advance()
+                tokens.append(Token(TokenType.COMMENT, "", start_line, start_col))
+                continue
+
+            # Multi-line comments !##! ... !##! or !# ... #!
+            if self.source.startswith("!##!", self.index):
+                start_line, start_col = self.line, self.col
+                self.index += 4
+                self.col += 4
+                while self.index < self.length and not self.source.startswith("!##!", self.index):
+                    self._advance()
+                if self.source.startswith("!##!", self.index):
+                    self.index += 4
+                    self.col += 4
+                tokens.append(Token(TokenType.COMMENT, "", start_line, start_col))
+                continue
+            if self.source.startswith("!#", self.index):
+                start_line, start_col = self.line, self.col
+                self.index += 2
+                self.col += 2
+                while self.index < self.length and not self.source.startswith("#!", self.index):
+                    self._advance()
+                if self.source.startswith("#!", self.index):
+                    self.index += 2
+                    self.col += 2
+                tokens.append(Token(TokenType.COMMENT, "", start_line, start_col))
+                continue
+
+            # Annotation token @@
+            if ch == "@" and self.index + 1 < self.length and self.source[self.index + 1] == "@":
+                tokens.append(Token(TokenType.ANNOTATION, "@@", self.line, self.col))
+                self.index += 2
+                self.col += 2
+                continue
+
+            # String literals
+            if ch == '"':
+                tokens.append(self._parse_string())
+                continue
+
+            # Numbers
+            if ch.isdigit():
+                tokens.append(self._parse_number())
+                continue
+
+            # Identifier or keyword
+            if ch.isalpha() or ch == "_":
+                tokens.append(self._parse_identifier())
+                continue
+
+            # Operators and punctuation
+            matched = None
+            for op in sorted(OPERATORS.keys(), key=len, reverse=True):
+                if self.source.startswith(op, self.index):
+                    matched = op
+                    break
+            if matched is not None:
+                tokens.append(Token(OPERATORS[matched], matched, self.line, self.col))
+                self.index += len(matched)
+                self.col += len(matched)
+                continue
+
+            # Unknown characters
+            tokens.append(Token(TokenType.UNKNOWN, ch, self.line, self.col))
+            self._advance()
+
+        tokens.append(Token(TokenType.EOF, "", self.line, self.col))
+        return tokens
+
+    # ------------------------------------------------------------------
+    def _parse_string(self) -> Token:
+        start_line, start_col = self.line, self.col
+        self._advance()  # consume opening quote
+        literal = ""
+        escape_map = {
+            "n": "\n",
+            "t": "\t",
+            "r": "\r",
+            "\\": "\\",
+            '"': '"',
+        }
+        while self.index < self.length and self._peek() != '"':
+            ch = self._peek()
+            if ch == "\\":
+                self._advance()
+                if self.index < self.length:
+                    esc = self._advance()
+                    literal += escape_map.get(esc, esc)
+                continue
+            literal += self._advance()
+        if self._peek() == '"':
+            self._advance()
+        return Token(TokenType.STRING, literal, start_line, start_col)
+
+    def _parse_number(self) -> Token:
+        start_line, start_col = self.line, self.col
+        num = self._advance()
+        while self.index < self.length and self._peek().isdigit():
+            num += self._advance()
+        if (
+            self.index < self.length
+            and self._peek() == "."
+            and self.index + 1 < self.length
+            and self.source[self.index + 1].isdigit()
+        ):
+            num += self._advance()  # consume '.'
+            while self.index < self.length and self._peek().isdigit():
+                num += self._advance()
+            return Token(TokenType.FLOAT, num, start_line, start_col)
+        return Token(TokenType.INTEGER, num, start_line, start_col)
+
+    def _parse_identifier(self) -> Token:
+        start_line, start_col = self.line, self.col
+        ident = self._advance()
+        while self.index < self.length and (self._peek().isalnum() or self._peek() == "_"):
+            ident += self._advance()
+        tk_type = KEYWORDS.get(ident, TokenType.IDENTIFIER)
+        return Token(tk_type, ident, start_line, start_col)
+
+
+def tokenize(source: str) -> List[Token]:
+    return Tokenizer(source).tokenize()

--- a/src/frontend/tokens.py
+++ b/src/frontend/tokens.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class TokenType(Enum):
+    # Generic token types
+    IDENTIFIER = auto()
+    INTEGER = auto()
+    FLOAT = auto()
+    STRING = auto()
+    COMMENT = auto()
+    EOF = auto()
+    UNKNOWN = auto()
+    ANNOTATION = auto()
+
+    # Keywords
+    IMPORT = auto()
+    AS = auto()
+    STATIC = auto()
+    DYNAMIC = auto()
+    LET = auto()
+    MUT = auto()
+    FUNC = auto()
+    STRUCT = auto()
+    CLASS = auto()
+    INTERFACE = auto()
+    TYPE = auto()
+    ENUM = auto()
+    PUBLIC = auto()
+    PRIVATE = auto()
+    OPERATOR_KW = auto()
+    OVERRIDE = auto()
+    IF = auto()
+    ELSE = auto()
+    FOR = auto()
+    IN = auto()
+    LOOP = auto()
+    DO = auto()
+    UNTIL = auto()
+    BREAK = auto()
+    CONTINUE = auto()
+    RETURN = auto()
+    RAISE = auto()
+    MATCH = auto()
+    CASE = auto()
+    NIL = auto()
+
+    # Operators and punctuation
+    PLUS = auto()
+    MINUS = auto()
+    STAR = auto()
+    SLASH = auto()
+    PERCENT = auto()
+    ASSIGN = auto()
+    EQEQ = auto()
+    NEQ = auto()
+    GE = auto()
+    LE = auto()
+    GREATER = auto()
+    LESS = auto()
+    PLUS_EQ = auto()
+    MINUS_EQ = auto()
+    STAR_EQ = auto()
+    SLASH_EQ = auto()
+    AND_AND = auto()
+    OR_OR = auto()
+    ARROW = auto()
+    FAT_ARROW = auto()
+    DOT = auto()
+    COMMA = auto()
+    COLON = auto()
+    SEMICOLON = auto()
+    RANGE = auto()
+    ELLIPSIS = auto()
+    QUESTION = auto()
+    NOT = auto()
+    TILDE = auto()
+    LPAREN = auto()
+    RPAREN = auto()
+    LBRACE = auto()
+    RBRACE = auto()
+    LBRACKET = auto()
+    RBRACKET = auto()
+
+
+@dataclass
+class Token:
+    type: TokenType
+    value: str
+    line: int
+    column: int
+
+
+KEYWORDS = {
+    "import": TokenType.IMPORT,
+    "as": TokenType.AS,
+    "static": TokenType.STATIC,
+    "dynamic": TokenType.DYNAMIC,
+    "let": TokenType.LET,
+    "mut": TokenType.MUT,
+    "func": TokenType.FUNC,
+    "struct": TokenType.STRUCT,
+    "class": TokenType.CLASS,
+    "interface": TokenType.INTERFACE,
+    "type": TokenType.TYPE,
+    "enum": TokenType.ENUM,
+    "public": TokenType.PUBLIC,
+    "private": TokenType.PRIVATE,
+    "operator": TokenType.OPERATOR_KW,
+    "override": TokenType.OVERRIDE,
+    "if": TokenType.IF,
+    "else": TokenType.ELSE,
+    "for": TokenType.FOR,
+    "in": TokenType.IN,
+    "loop": TokenType.LOOP,
+    "do": TokenType.DO,
+    "until": TokenType.UNTIL,
+    "break": TokenType.BREAK,
+    "continue": TokenType.CONTINUE,
+    "return": TokenType.RETURN,
+    "raise": TokenType.RAISE,
+    "match": TokenType.MATCH,
+    "case": TokenType.CASE,
+    "nil": TokenType.NIL,
+}
+
+
+OPERATORS = {
+    "==": TokenType.EQEQ,
+    "!=": TokenType.NEQ,
+    ">=": TokenType.GE,
+    "<=": TokenType.LE,
+    "+=": TokenType.PLUS_EQ,
+    "-=": TokenType.MINUS_EQ,
+    "*=": TokenType.STAR_EQ,
+    "/=": TokenType.SLASH_EQ,
+    "&&": TokenType.AND_AND,
+    "||": TokenType.OR_OR,
+    "->": TokenType.ARROW,
+    "=>": TokenType.FAT_ARROW,
+    "+": TokenType.PLUS,
+    "-": TokenType.MINUS,
+    "*": TokenType.STAR,
+    "/": TokenType.SLASH,
+    "%": TokenType.PERCENT,
+    "=": TokenType.ASSIGN,
+    ">": TokenType.GREATER,
+    "<": TokenType.LESS,
+    "!": TokenType.NOT,
+    "?": TokenType.QUESTION,
+    "~": TokenType.TILDE,
+    ".": TokenType.DOT,
+    ",": TokenType.COMMA,
+    ":": TokenType.COLON,
+    ";": TokenType.SEMICOLON,
+    "..": TokenType.RANGE,
+    "...": TokenType.ELLIPSIS,
+    "(": TokenType.LPAREN,
+    ")": TokenType.RPAREN,
+    "{": TokenType.LBRACE,
+    "}": TokenType.RBRACE,
+    "[": TokenType.LBRACKET,
+    "]": TokenType.RBRACKET,
+}

--- a/tests/test_frontend_tokenizer.py
+++ b/tests/test_frontend_tokenizer.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.frontend.tokenization import Tokenizer, tokenize
+from src.frontend.tokens import TokenType
+
+
+def test_basic_tokens():
+    tokens = tokenize("let x = 10;")
+    types = [t.type for t in tokens]
+    assert types[0] == TokenType.LET
+    assert types[1] == TokenType.IDENTIFIER
+    assert types[2] == TokenType.ASSIGN
+    assert types[3] == TokenType.INTEGER
+    assert types[4] == TokenType.SEMICOLON
+    assert tokens[-1].type == TokenType.EOF
+
+
+def test_string_escapes():
+    src = "\"foo\\nbar\\t\\\"baz\\\"\\\\\""
+    tokens = tokenize(src)
+    assert tokens[0].type == TokenType.STRING
+    assert tokens[0].value == 'foo\nbar\t"baz"\\'
+


### PR DESCRIPTION
## Summary
- create `frontend` package with token definitions
- implement new tokenizer using `TokenType` enum and centralized keyword/operator maps
- add unit tests for the new tokenizer

## Testing
- `pytest tests/test_frontend_tokenizer.py -q`
- `pytest -q` *(fails: undefined symbol in runtime)*

------
https://chatgpt.com/codex/tasks/task_b_686542aeb6388321b327fcb746fff98b