### PR TITLE
Add allocator and numeric types

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -22,7 +22,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # --- 查找所有源文件 ---
 # 递归查找impl目录下的所有.cpp文件
 file(GLOB_RECURSE IMPL_SOURCES "impl/*.cpp")
+file(GLOB_RECURSE SRC_SOURCES "src/*.cpp")
 list(APPEND IMPL_SOURCES "impl/object.cpp")
+list(APPEND IMPL_SOURCES ${SRC_SOURCES})
 
 # --- 定义要构建的目标 ---
 # 将所有源文件编译成一个名为 "runtime" 的共享库 (最终生成 <project_root>/bin/libruntime.so)

--- a/runtime/impl/boolean.cpp
+++ b/runtime/impl/boolean.cpp
@@ -10,8 +10,31 @@ namespace mxs_runtime {
     MXS_API const MXBoolean &MXTRUE = mx_true_instance;
     MXS_API const MXBoolean &MXFALSE = mx_false_instance;
 
+    MXBoolean::MXBoolean() : MXObject(), value(false) {
+        this->set_type_name("boolean");
+    }
+
     MXBoolean::MXBoolean(inner_boolean v) : MXObject(), value(v) {
         this->set_type_name("boolean");
+    }
+
+    MXBoolean::~MXBoolean() = default;
+
+    inner_boolean MXBoolean::equals(const MXObject &other) {
+        const MXBoolean *b = dynamic_cast<const MXBoolean*>(&other);
+        return b && b->value == value;
+    }
+
+    inner_boolean MXBoolean::equals(const MXObject *other) {
+        return other && equals(*other);
+    }
+
+    inner_boolean MXBoolean::equals(const MXBoolean &other) {
+        return value == other.value;
+    }
+
+    inner_boolean MXBoolean::equals(const MXBoolean *other) {
+        return other && value == other->value;
     }
 
 }// namespace

--- a/runtime/impl/object.cpp
+++ b/runtime/impl/object.cpp
@@ -1,11 +1,14 @@
 #include "include/object.hpp"
 #include "_typedef.hpp"
+#include "allocator.hpp"
 #include <cstring>
 
 namespace mxs_runtime {
 
     MXObject::MXObject() = default;
-    MXObject::~MXObject() = default;
+    MXObject::~MXObject() {
+        MX_ALLOCATOR.unregisterObject(this);
+    }
 
     MXObject::MXObject(const MXObject &other)
         : ref_cnt(other.ref_cnt), object_type_name(other.object_type_name) { }
@@ -23,6 +26,7 @@ namespace mxs_runtime {
 
     inner_boolean MXObject::equals(const MXObject &other) { return this == &other; }
     inner_boolean MXObject::equals(const MXObject *other) { return this == other; }
+    hash_code_type MXObject::hash_code() { return reinterpret_cast<hash_code_type>(this); }
 
 
 }// namespace mxs_runtime

--- a/runtime/include/_typedef.hpp
+++ b/runtime/include/_typedef.hpp
@@ -8,6 +8,8 @@ namespace mxs_runtime {
     using hash_code_type = std::uint64_t;
     using inner_string = std::string;
     using inner_boolean = bool;
+    using inner_integer = std::int64_t;
+    using inner_float = double;
     using refer_count_type = std::uint64_t;
 }
 

--- a/runtime/include/allocator.hpp
+++ b/runtime/include/allocator.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef MXSCRIPT_ALLOCATOR_HPP
+#define MXSCRIPT_ALLOCATOR_HPP
+
+#include "macro.hpp"
+#include <unordered_set>
+#include <mutex>
+
+namespace mxs_runtime {
+    class MXObject; // forward declaration
+
+    class Allocator {
+    private:
+        std::unordered_set<MXObject*> objects;
+        std::mutex mtx;
+    public:
+        void registerObject(MXObject* obj);
+        void unregisterObject(MXObject* obj);
+    };
+
+    MXS_API extern Allocator& MX_ALLOCATOR;
+}
+
+#endif // MXSCRIPT_ALLOCATOR_HPP

--- a/runtime/include/float.hpp
+++ b/runtime/include/float.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#ifndef MXSCRIPT_FLOAT_HPP
+#define MXSCRIPT_FLOAT_HPP
+
+#include "_typedef.hpp"
+#include "macro.hpp"
+#include "object.hpp"
+
+namespace mxs_runtime {
+    class MXFloat : public MXObject {
+    public:
+        const inner_float value;
+        explicit MXFloat(inner_float v);
+    };
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+MXS_API mxs_runtime::MXFloat* MXCreateFloat(mxs_runtime::inner_float value);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MXSCRIPT_FLOAT_HPP

--- a/runtime/include/integer.hpp
+++ b/runtime/include/integer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef MXSCRIPT_INTEGER_HPP
+#define MXSCRIPT_INTEGER_HPP
+
+#include "_typedef.hpp"
+#include "macro.hpp"
+#include "object.hpp"
+
+namespace mxs_runtime {
+    class MXInteger : public MXObject {
+    public:
+        const inner_integer value;
+        explicit MXInteger(inner_integer v);
+    };
+}
+
+// C API
+#ifdef __cplusplus
+extern "C" {
+#endif
+MXS_API mxs_runtime::MXInteger* MXCreateInteger(mxs_runtime::inner_integer value);
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MXSCRIPT_INTEGER_HPP

--- a/runtime/src/allocator.cpp
+++ b/runtime/src/allocator.cpp
@@ -1,0 +1,21 @@
+#include "allocator.hpp"
+#include "object.hpp"
+
+namespace mxs_runtime {
+
+static Allocator allocator_instance;
+MXS_API Allocator& MX_ALLOCATOR = allocator_instance;
+
+void Allocator::registerObject(MXObject* obj) {
+    if (!obj) return;
+    std::lock_guard<std::mutex> lock(mtx);
+    objects.insert(obj);
+}
+
+void Allocator::unregisterObject(MXObject* obj) {
+    if (!obj) return;
+    std::lock_guard<std::mutex> lock(mtx);
+    objects.erase(obj);
+}
+
+} // namespace mxs_runtime

--- a/runtime/src/float.cpp
+++ b/runtime/src/float.cpp
@@ -1,0 +1,18 @@
+#include "float.hpp"
+#include "allocator.hpp"
+
+namespace mxs_runtime {
+
+MXFloat::MXFloat(inner_float v) : MXObject(), value(v) {
+    this->set_type_name("float");
+}
+
+} // namespace mxs_runtime
+
+extern "C" {
+MXS_API mxs_runtime::MXFloat* MXCreateFloat(mxs_runtime::inner_float value) {
+    auto* obj = new mxs_runtime::MXFloat(value);
+    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
+    return obj;
+}
+}

--- a/runtime/src/integer.cpp
+++ b/runtime/src/integer.cpp
@@ -1,0 +1,18 @@
+#include "integer.hpp"
+#include "allocator.hpp"
+
+namespace mxs_runtime {
+
+MXInteger::MXInteger(inner_integer v) : MXObject(), value(v) {
+    this->set_type_name("integer");
+}
+
+} // namespace mxs_runtime
+
+extern "C" {
+MXS_API mxs_runtime::MXInteger* MXCreateInteger(mxs_runtime::inner_integer value) {
+    auto* obj = new mxs_runtime::MXInteger(value);
+    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
+    return obj;
+}
+}


### PR DESCRIPTION
## Summary
- provide a runtime `Allocator` that tracks live objects
- register/unregister objects with the allocator
- implement `MXInteger` and `MXFloat` runtime types
- expose factories to create integer and float objects
- add missing basic implementations for boolean class
- define hash function for `MXObject`
- extend CMakeLists to build new runtime sources

## Testing
- `pytest -q` *(fails: undefined symbol errors)*

------
https://chatgpt.com/codex/tasks/task_b_686543c2967c832182c9910878ec2243