### PR TITLE
Fix tokenizer operator categories

### DIFF
--- a/src/frontend/tokens.py
+++ b/src/frontend/tokens.py
@@ -4,6 +4,29 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 
+class _TokenCategory:
+    """Wrapper providing backward-compatible ``name`` and comparison behaviour."""
+
+    def __init__(self, token_type: 'TokenType', category: str | None = None) -> None:
+        self.actual = token_type
+        self.name = category or token_type.name
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        if isinstance(other, TokenType):
+            return self.actual == other
+        if isinstance(other, str):
+            return self.name == other
+        if isinstance(other, _TokenCategory):
+            return self.actual == other.actual
+        return False
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        return hash(self.actual)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<_TokenCategory {self.name}:{self.actual.name}>"
+
+
 class TokenType(Enum):
     # Generic token types
     IDENTIFIER = auto()
@@ -87,7 +110,7 @@ class TokenType(Enum):
 
 @dataclass
 class Token:
-    type: TokenType
+    type: _TokenCategory
     value: str
     line: int
     column: int


### PR DESCRIPTION
## Summary
- wrap token types with `_TokenCategory` to retain enum equality while exposing
  generic names like `OPERATOR`
- emit `_TokenCategory` objects from the tokenizer so parentheses and other
  operators match parser expectations

## Testing
- `pytest tests/test_frontend_tokenizer.py::test_basic_tokens -q`
- `python main.py examples/hello_world.mxs` *(fails at runtime due to missing library after successful parsing)*
- `pytest -q` *(fails: RuntimeError from LLVM library)*

------
https://chatgpt.com/codex/tasks/task_b_6865491781c8832194fafee00ea50951