### PR TITLE
Add REPL shell and allocator stats

### DIFF
--- a/runtime/impl/allocator.cpp
+++ b/runtime/impl/allocator.cpp
@@ -1,5 +1,6 @@
 #include "allocator.hpp"
 #include "object.hpp"
+#include <cstdio>
 
 namespace mxs_runtime {
 
@@ -18,4 +19,17 @@ void Allocator::unregisterObject(MXObject* obj) {
     objects.erase(obj);
 }
 
+void Allocator::dump_stats() {
+    std::lock_guard<std::mutex> lock(mtx);
+    printf("Live objects: %zu\n", objects.size());
+    for (MXObject* obj : objects) {
+        const char* type = obj ? obj->get_type_name().c_str() : "<null>";
+        printf("  %p (%s)\n", (void*)obj, type);
+    }
+}
+
 } // namespace mxs_runtime
+
+extern "C" MXS_API void mxs_allocator_dump_stats() {
+    mxs_runtime::MX_ALLOCATOR.dump_stats();
+}

--- a/runtime/include/allocator.hpp
+++ b/runtime/include/allocator.hpp
@@ -16,9 +16,14 @@ namespace mxs_runtime {
     public:
         void registerObject(MXObject* obj);
         void unregisterObject(MXObject* obj);
+        void dump_stats();
     };
 
     MXS_API extern Allocator& MX_ALLOCATOR;
+}
+
+extern "C" {
+MXS_API void mxs_allocator_dump_stats();
 }
 
 #endif // MXSCRIPT_ALLOCATOR_HPP

--- a/src/cui/shell.py
+++ b/src/cui/shell.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+from src.frontend import tokenize, TokenStream
+from src.syntax_parser import Parser
+from src.semantic_analyzer import SemanticAnalyzer
+from src.backend import compile_program, execute_llvm, build_search_paths
+from src.errors import CompilerError
+
+
+def _load_runtime_lib() -> ctypes.CDLL:
+    """Load the runtime shared library and return its CDLL handle."""
+    base_dir = Path(__file__).resolve().parents[2]
+    so_path = base_dir / "bin" / "libruntime.so"
+    if not so_path.exists():
+        from src.backend.llir import _load_runtime
+
+        _load_runtime()
+    return ctypes.CDLL(str(so_path))
+
+
+def run_shell() -> int:
+    """Start an interactive MxScript REPL."""
+    runtime = None
+    while True:
+        try:
+            line = input("mxs> ")
+        except EOFError:
+            print()
+            break
+
+        if not line.strip():
+            continue
+
+        if line.strip() == ":mem":
+            if runtime is None:
+                runtime = _load_runtime_lib()
+            try:
+                runtime.mxs_allocator_dump_stats()
+            except Exception as exc:  # pragma: no cover - debug helper
+                print(f"Error calling dump_stats: {exc}")
+            continue
+
+        try:
+            tokens = tokenize(line)
+            stream = TokenStream(tokens)
+            parser = Parser(stream, source=line, filename="<repl>")
+            ast = parser.parse()
+
+            sema = SemanticAnalyzer()
+            sema.analyze(ast, source=line, filename="<repl>")
+
+            search_paths = build_search_paths(None)
+            ir = compile_program(ast, search_paths=search_paths)
+            result = execute_llvm(ir)
+            if result is not None:
+                print(result)
+        except CompilerError as e:  # pragma: no cover - debug helper
+            print(f"Error: {e.message}")
+    return 0
+


### PR DESCRIPTION
## Summary
- implement a small REPL in `src/cui/shell.py`
- expose allocator statistics through a new C API
- add command line flags for dumping tokens, AST and LLVM IR
- start REPL when no input file is supplied

## Testing
- `cmake --build .` in runtime
- `pytest -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68654d2eca388321aa91366c2041aaaf