### PR TITLE
Finalize RTTI and semantic analyzer

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.10)
 project(mx_runtime CXX C)
 
 # 设置C++标准
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --- 设置输出目录 ---

--- a/runtime/impl/boolean.cpp
+++ b/runtime/impl/boolean.cpp
@@ -3,15 +3,15 @@
 
 namespace mxs_runtime {
 
+    static const RTTI RTTI_BOOLEAN{"Boolean"};
     static MXBoolean true_instance{ true };
     static MXBoolean false_instance{ false };
 
     MXS_API const MXBoolean &MX_TRUE = true_instance;
     MXS_API const MXBoolean &MX_FALSE = false_instance;
 
-    MXBoolean::MXBoolean(inner_boolean v) : MXObject(true), value(v) {
-        this->set_type_name("boolean");
-    }
+    MXBoolean::MXBoolean(inner_boolean v)
+        : MXObject(&RTTI_BOOLEAN, true), value(v) {}
 
     auto MXBoolean::repr() const -> inner_string { return value ? "true" : "false"; }
 
@@ -19,7 +19,11 @@ namespace mxs_runtime {
 
 extern "C" {
 
-const mxs_runtime::MXBoolean *mxs_get_true() { return &mxs_runtime::MX_TRUE; }
-const mxs_runtime::MXBoolean *mxs_get_false() { return &mxs_runtime::MX_FALSE; }
+auto mxs_get_true() -> const mxs_runtime::MXBoolean* {
+    return &mxs_runtime::MX_TRUE;
+}
+auto mxs_get_false() -> const mxs_runtime::MXBoolean* {
+    return &mxs_runtime::MX_FALSE;
+}
 
 }// extern "C"

--- a/runtime/impl/functions.cpp
+++ b/runtime/impl/functions.cpp
@@ -8,17 +8,26 @@
 #include <cstdio>
 #include <iostream>
 #include <ostream>
+#if __has_include(<print>)
+#  include <print>
+#else
+#  include <format>
+#  include <cstdio>
+namespace std {
+    template <class... Args>
+    void print(std::format_string<Args...> fmt, Args&&... args) {
+        std::fputs(std::format(fmt, std::forward<Args>(args)...).c_str(), stdout);
+    }
+}
+#endif
 
 namespace mxs_runtime {
-    inner_string type_of(const MXObject *obj) { return obj->get_type_name(); }
-    inner_string type_of(const MXObject &obj) { return obj.get_type_name(); }
+    auto type_of(const MXObject* obj) -> inner_string { return obj->get_type_name(); }
+    auto type_of(const MXObject& obj) -> inner_string { return obj.get_type_name(); }
 }
 
-extern "C" std::size_t mx_print(mxs_runtime::MXObject *obj) {
-    using namespace mxs_runtime;
-    auto repr = obj->repr();
-    std::fprintf(stdout, "%s", repr.c_str());
-    std::fflush(stdout);
-
-    return repr.length();
+extern "C" auto mxs_print_object(mxs_runtime::MXObject* obj) -> std::size_t {
+    auto text = obj->repr();
+    std::print("{}\n", text);
+    return text.length();
 }

--- a/runtime/impl/nil.cpp
+++ b/runtime/impl/nil.cpp
@@ -3,17 +3,20 @@
 
 namespace mxs_runtime {
 
+    static const RTTI RTTI_NIL{"Nil"};
     static MXNil nil_instance;
 
     MXS_API const MXNil &MX_NIL = nil_instance;
 
-    MXNil::MXNil() : MXObject(true) { this->set_type_name("nil"); }
+    MXNil::MXNil() : MXObject(&RTTI_NIL, true) {}
     auto MXNil::repr() const -> inner_string { return "nil"; }
 
 }// namespace mxs_runtime
 
 extern "C" {
 
-const mxs_runtime::MXNil *mxs_get_nil() { return &mxs_runtime::MX_NIL; }
+auto mxs_get_nil() -> const mxs_runtime::MXNil* {
+    return &mxs_runtime::MX_NIL;
+}
 
 }// extern "C"

--- a/runtime/impl/numeric.cpp
+++ b/runtime/impl/numeric.cpp
@@ -1,30 +1,35 @@
 #include "numeric.hpp"
 #include "allocator.hpp"
+#include <format>
 
 namespace mxs_runtime {
 
-MXNumeric::MXNumeric(bool is_static) : MXObject(is_static) {
-    this->set_type_name("numeric");
-}
+static const RTTI RTTI_INTEGER{"Integer"};
+static const RTTI RTTI_FLOAT{"Float"};
 
-MXInteger::MXInteger(inner_integer v) : MXNumeric(false), value(v) {
-    this->set_type_name("integer");
-}
+MXNumeric::MXNumeric(const RTTI* rtti, bool is_static) : MXObject(rtti, is_static) {}
 
-MXFloat::MXFloat(inner_float v) : MXNumeric(false), value(v) {
-    this->set_type_name("float");
+MXInteger::MXInteger(inner_integer v) : MXNumeric(&RTTI_INTEGER, false), value(v) {}
+
+auto MXInteger::to_string() const -> inner_string {
+    return std::format("{}", value);
+}
+MXFloat::MXFloat(inner_float v) : MXNumeric(&RTTI_FLOAT, false), value(v) {}
+
+auto MXFloat::to_string() const -> inner_string {
+    return std::format("{}", value);
 }
 } // namespace mxs_runtime
 
 extern "C" {
 
-MXS_API mxs_runtime::MXInteger* MXCreateInteger(mxs_runtime::inner_integer value) {
+auto MXCreateInteger(mxs_runtime::inner_integer value) -> mxs_runtime::MXInteger* {
     auto* obj = new mxs_runtime::MXInteger(value);
     mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     return obj;
 }
 
-MXS_API mxs_runtime::MXFloat* MXCreateFloat(mxs_runtime::inner_float value) {
+auto MXCreateFloat(mxs_runtime::inner_float value) -> mxs_runtime::MXFloat* {
     auto* obj = new mxs_runtime::MXFloat(value);
     mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     return obj;

--- a/runtime/impl/object.cpp
+++ b/runtime/impl/object.cpp
@@ -5,24 +5,26 @@
 
 namespace mxs_runtime {
 
-    MXObject::MXObject(bool is_static) : _is_static(is_static) { }
+    static const RTTI RTTI_OBJECT{"object"};
+
+    MXObject::MXObject(const RTTI* rtti_ptr, bool is_static)
+        : rtti(rtti_ptr), _is_static(is_static) {}
     MXObject::~MXObject() {
         if (!_is_static) { MX_ALLOCATOR.unregisterObject(this); }
     }
 
-    MXObject::MXObject(const MXObject &other)
-        : ref_cnt(other.ref_cnt), object_type_name(other.object_type_name),
-          _is_static(other._is_static) { }
+    MXObject::MXObject(const MXObject& other)
+        : rtti(other.rtti), _is_static(other._is_static) {}
 
     auto MXObject::increase_ref() -> refer_count_type { return ++ref_cnt; }
 
-    refer_count_type MXObject::decrease_ref() {
+    auto MXObject::decrease_ref() -> refer_count_type {
         if (ref_cnt > 0) { --ref_cnt; }
         return ref_cnt;
     }
 
-    auto MXObject::get_type_name() const -> const std::string & {
-        return object_type_name;
+    auto MXObject::get_type_name() const -> const std::string& {
+        return rtti->type_name;
     }
 
     auto MXObject::equals(const MXObject &other) -> inner_boolean {
@@ -35,46 +37,44 @@ namespace mxs_runtime {
         return reinterpret_cast<hash_code_type>(this);
     }
 
-    auto MXObject::repr() const -> inner_string { return object_type_name; }
+    auto MXObject::repr() const -> inner_string { return rtti->type_name; }
 
 
 }// namespace mxs_runtime
 
 extern "C" {
 
-mxs_runtime::MXObject *new_mx_object() { return new mxs_runtime::MXObject(); }
+auto new_mx_object() -> mxs_runtime::MXObject* {
+    return new mxs_runtime::MXObject(&mxs_runtime::RTTI_OBJECT);
+}
 
-void delete_mx_object(mxs_runtime::MXObject *obj) { delete obj; }
+auto delete_mx_object(mxs_runtime::MXObject* obj) -> void { delete obj; }
 
-mxs_runtime::refer_count_type increase_ref(mxs_runtime::MXObject *obj) {
+auto increase_ref(mxs_runtime::MXObject* obj) -> mxs_runtime::refer_count_type {
     if (!obj) return 0;
     return obj->increase_ref();
 }
 
-mxs_runtime::refer_count_type decrease_ref(mxs_runtime::MXObject *obj) {
+auto decrease_ref(mxs_runtime::MXObject* obj) -> mxs_runtime::refer_count_type {
     if (!obj) return 0;
     std::size_t cnt = obj->decrease_ref();
     if (cnt == 0) { delete obj; }
     return cnt;
 }
 
-const char *get_object_type_name(mxs_runtime::MXObject *obj) {
+auto mxs_get_object_type_name(mxs_runtime::MXObject* obj) -> const char* {
     if (!obj) return nullptr;
     return obj->get_type_name().c_str();
 }
 
-void set_object_type_name(mxs_runtime::MXObject *obj, const char *name) {
-    if (!obj) return;
-    obj->set_type_name(name ? std::string(name) : std::string());
-}
-
-std::size_t mx_object_repr_length(mxs_runtime::MXObject *obj) {
+auto mx_object_repr_length(mxs_runtime::MXObject* obj) -> std::size_t {
     if (!obj) return 0;
     return obj->repr().length();
 }
 
 
-void mx_object_repr(mxs_runtime::MXObject *obj, char *buffer, std::size_t buffer_size) {
+auto mx_object_repr(mxs_runtime::MXObject* obj, char* buffer,
+                    std::size_t buffer_size) -> void {
     if (!obj || !buffer || buffer_size == 0) return;
     std::string repr = obj->repr();
     std::strncpy(buffer, repr.c_str(), buffer_size - 1);

--- a/runtime/include/functions.hpp
+++ b/runtime/include/functions.hpp
@@ -10,5 +10,5 @@ namespace mxs_runtime {
     inner_string type_of(const MXObject &obj);
 }
 
-extern "C" std::size_t mx_print(mxs_runtime::MXObject *obj);
+extern "C" std::size_t mxs_print_object(mxs_runtime::MXObject *obj);
 #endif// MX_FUNCTIONS_HPP

--- a/runtime/include/numeric.hpp
+++ b/runtime/include/numeric.hpp
@@ -10,23 +10,23 @@ namespace mxs_runtime {
 
     class MXNumeric : public MXObject {
     public:
-        explicit MXNumeric(bool is_static = false);
+        explicit MXNumeric(const RTTI* rtti, bool is_static = false);
+        virtual auto to_string() const -> std::string = 0;
+        auto repr() const -> inner_string override { return to_string(); }
     };
 
     class MXInteger : public MXNumeric {
     public:
         const inner_integer value;
         explicit MXInteger(inner_integer v);
-        // auto to_string() const -> MXString;
-        auto to_string() const -> inner_string;
-        auto repr() const -> inner_string override;
+        auto to_string() const -> inner_string override;
     };
 
     class MXFloat : public MXNumeric {
     public:
         const inner_float value;
         explicit MXFloat(inner_float v);
-        auto repr() const -> inner_string override;
+        auto to_string() const -> inner_string override;
     };
 
     MXS_API MXInteger *MXCreateInteger(inner_integer value);

--- a/runtime/include/object.hpp
+++ b/runtime/include/object.hpp
@@ -7,27 +7,32 @@
 #include "macro.hpp"
 #include <cstddef>
 #include <string>
+
 namespace mxs_runtime {
+
+    struct RTTI {
+        std::string type_name;
+    };
+
     class MXObject {
     private:
         refer_count_type ref_cnt = 0;
-        std::string object_type_name{ "object" };
+        const RTTI* const rtti;
         bool _is_static = false;
 
     public:
-        explicit MXObject(bool is_static = false);
-        MXObject(const MXObject &other);
+        explicit MXObject(const RTTI* rtti, bool is_static = false);
+        MXObject(const MXObject& other);
         virtual ~MXObject();
-        refer_count_type increase_ref();
-        refer_count_type decrease_ref();
-        const std::string &get_type_name() const;
-        void set_type_name(const std::string &name);
-        virtual inner_boolean equals(const MXObject &other);
-        virtual inner_boolean equals(const MXObject *other);
-        virtual hash_code_type hash_code();
-
-        virtual inner_string repr() const;// return a representation in string form
+        auto increase_ref() -> refer_count_type;
+        auto decrease_ref() -> refer_count_type;
+        auto get_type_name() const -> const std::string&;
+        virtual auto equals(const MXObject& other) -> inner_boolean;
+        virtual auto equals(const MXObject* other) -> inner_boolean;
+        virtual auto hash_code() -> hash_code_type;
+        virtual auto repr() const -> inner_string; // return a representation in string form
     };
+
 }// namespace mxs_runtime
 
 
@@ -40,12 +45,12 @@ mxs_runtime::MXObject *new_mx_object();
 void delete_mx_object(mxs_runtime::MXObject *obj);
 std::size_t increase_ref(mxs_runtime::MXObject *obj);
 std::size_t decrease_ref(mxs_runtime::MXObject *obj);
-const char *get_object_type_name(mxs_runtime::MXObject *obj);
-void set_object_type_name(mxs_runtime::MXObject *obj, const char *name);
+const char *mxs_get_object_type_name(mxs_runtime::MXObject *obj);
 mxs_runtime::inner_boolean mx_object_equals(mxs_runtime::MXObject *obj1,
                                             mxs_runtime::MXObject *obj2);
 std::size_t mx_object_repr_length(mxs_runtime::MXObject *obj);
-void mx_object_repr(mxs_runtime::MXObject *obj, char *buffer, std::size_t buffer_size);
+void mx_object_repr(mxs_runtime::MXObject *obj, char *buffer,
+                    std::size_t buffer_size);
 #ifdef __cplusplus
 }
 #endif

--- a/src/backend/ffi_map.json
+++ b/src/backend/ffi_map.json
@@ -6,7 +6,7 @@
   "close": {"ret": "int32", "args": ["int32"]},
   "malloc": {"ret": "char_ptr", "args": ["int64"]},
   "free": {"ret": "void", "args": ["char_ptr"]},
-  "mxs_print_object": {"ret": "void", "args": ["char_ptr"]},
+  "mxs_print_object": {"ret": "int64", "args": ["char_ptr"]},
   "new_mx_object": {"ret": "char_ptr", "args": []},
   "increase_ref": {"ret": "int64", "args": ["char_ptr"]},
   "decrease_ref": {"ret": "int64", "args": ["char_ptr"]},

--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -72,6 +72,15 @@ class SemanticAnalyzer:
     source_lines: List[str] = field(default_factory=list)
     loop_depth: int = 0
 
+    def __init__(self) -> None:
+        self.variables_stack = None
+        self.functions = None
+        self.type_registry = None
+        self.filename = "<stdin>"
+        self.source_lines = []
+        self.loop_depth = 0
+        self.builtin_functions: Set[str] = {"print"}
+
     def analyze(self, program: Program, *, source: str = "", filename: str = "<stdin>") -> None:
         self.filename = filename
         self.source_lines = source.splitlines()
@@ -373,7 +382,12 @@ class SemanticAnalyzer:
                 for arg in expr.args:
                     self._visit_expression(arg)
             else:
-                if '.' not in expr.name and self.functions is not None and expr.name not in self.functions:
+                if (
+                    '.' not in expr.name
+                    and self.functions is not None
+                    and expr.name not in self.functions
+                    and expr.name not in self.builtin_functions
+                ):
                     raise NameError(
                         f"Undefined function '{expr.name}'",
                         self._get_location(expr.loc),


### PR DESCRIPTION
## Summary
- switch runtime to static RTTI and remove mutable type names
- implement numeric printing and new builtin print
- expose builtin function registry in semantic analyzer
- update FFI map for new print function

## Testing
- `python main.py examples/print_test.mxs`
- `pytest -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6865f2d8e06c8321b6e9e804946ce1ab