### PR TITLE
Partially fix LLVM backend for constant handling

### DIFF
--- a/src/backend/ffi_map.json
+++ b/src/backend/ffi_map.json
@@ -1,21 +1,123 @@
 {
-  "printf": {"ret": "int32", "args": ["cstr_ptr"], "var_arg": true},
-  "write": {"ret": "int64", "args": ["int32", "cstr_ptr", "int64"]},
-  "read": {"ret": "int64", "args": ["int32", "cstr_ptr", "int64"]},
-  "open": {"ret": "int64", "args": ["cstr_ptr", "int32", "int32"]},
-  "close": {"ret": "int32", "args": ["int32"]},
-  "malloc": {"ret": "cstr_ptr", "args": ["int64"]},
-  "free": {"ret": "void", "args": ["cstr_ptr"]},
-  "mxs_print_object": {"ret": "int64", "args": ["char_ptr"]},
-  "new_mx_object": {"ret": "char_ptr", "args": []},
-  "increase_ref": {"ret": "int64", "args": ["char_ptr"]},
-  "decrease_ref": {"ret": "int64", "args": ["char_ptr"]},
-  "MXCreateInteger": {"ret": "char_ptr", "args": ["int64"]},
-    "MXCreateFloat": {"ret": "char_ptr", "args": ["double"]},
-  "MXCreateString": {"ret": "char_ptr", "args": ["cstr_ptr"]},
-    "mxs_get_true": {"ret": "char_ptr", "args": []},
-  "mxs_get_false": {"ret": "char_ptr", "args": []},
-  "mxs_get_nil": {"ret": "char_ptr", "args": []},
-  "time_now": {"name": "time", "ret": "int64", "args": ["cstr_ptr"], "wrapper_args": []},
-  "random_rand": {"name": "rand", "ret": "int32", "args": [], "wrapper_args": []}
+    "printf": {
+        "ret": "int32",
+        "args": [
+            "cstr_ptr"
+        ],
+        "var_arg": true
+    },
+    "write": {
+        "ret": "int64",
+        "args": [
+            "int32",
+            "cstr_ptr",
+            "int64"
+        ]
+    },
+    "read": {
+        "ret": "int64",
+        "args": [
+            "int32",
+            "cstr_ptr",
+            "int64"
+        ]
+    },
+    "open": {
+        "ret": "int64",
+        "args": [
+            "cstr_ptr",
+            "int32",
+            "int32"
+        ]
+    },
+    "close": {
+        "ret": "int32",
+        "args": [
+            "int32"
+        ]
+    },
+    "malloc": {
+        "ret": "cstr_ptr",
+        "args": [
+            "int64"
+        ]
+    },
+    "free": {
+        "ret": "void",
+        "args": [
+            "cstr_ptr"
+        ]
+    },
+    "mxs_print_object": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    },
+    "new_mx_object": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "increase_ref": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    },
+    "decrease_ref": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    },
+    "MXCreateInteger": {
+        "ret": "char_ptr",
+        "args": [
+            "int64"
+        ]
+    },
+    "MXCreateFloat": {
+        "ret": "char_ptr",
+        "args": [
+            "double"
+        ]
+    },
+    "MXCreateString": {
+        "ret": "char_ptr",
+        "args": [
+            "cstr_ptr"
+        ]
+    },
+    "mxs_get_true": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "mxs_get_false": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "mxs_get_nil": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "time_now": {
+        "name": "time",
+        "ret": "int64",
+        "args": [
+            "cstr_ptr"
+        ],
+        "wrapper_args": []
+    },
+    "random_rand": {
+        "name": "rand",
+        "ret": "int32",
+        "args": [],
+        "wrapper_args": []
+    },
+    "strlen": {
+        "ret": "int64",
+        "args": [
+            "cstr_ptr"
+        ]
+    }
 }

--- a/src/backend/llir.py
+++ b/src/backend/llir.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import os
 
 from llvmlite import binding
+import sys
 
 from .compiler import (
     build_search_paths,
@@ -58,13 +59,13 @@ def _load_runtime() -> None:
 
         subprocess.run(
             ["cmake", str(runtime_dir)],
-            cwd=build_dir, # 在构建目录中运行
+            cwd=build_dir,  # 在构建目录中运行
             check=True,
         )
 
         subprocess.run(
             ["cmake", "--build", "."],
-            cwd=build_dir, # 在构建目录中运行
+            cwd=build_dir,  # 在构建目录中运行
             check=True,
         )
         print("Runtime library built successfully.")
@@ -102,6 +103,7 @@ class CondBr(LLIRInstr):
     cond: str
     then_label: str
     else_label: str
+
 
 LLIRInstr = Union[
     Instr,
@@ -180,4 +182,11 @@ def execute_llvm(program: ProgramIR) -> int:
 
     cfunc = CFUNCTYPE(c_longlong)(func_ptr)
     result = cfunc()
+    sys.stdout.flush()
+    try:
+        import ctypes
+
+        ctypes.CDLL(None).fflush(None)
+    except Exception:
+        pass
     return int(result)


### PR DESCRIPTION
## Summary
- refine LLVM generator to treat constants as raw values
- auto-cast when storing or returning values
- flush stdout when executing LLVM code
- update print code generation and ABI map

## Testing
- `pytest tests/test_llvm_backend.py::test_if_true_condition -q`
- `pytest tests/test_backend.py::test_print_functions -q`


------
https://chatgpt.com/codex/tasks/task_b_6866088be52c8321a6f497a985d16136