### PR TITLE
Support printing variables

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -54,9 +54,18 @@ def test_backend_return_statement():
 
 
 def test_print_functions(capfd):
-    compile_and_run('print(101); print(true);')
+    src = (
+        'func main() -> nil {\n'
+        '    let i = 101;\n'
+        '    let f = 2.5;\n'
+        '    print(i);\n'
+        '    print(f);\n'
+        '    print(true);\n'
+        '}'
+    )
+    compile_and_run(src)
     captured = capfd.readouterr()
-    assert captured.out == "101true"
+    assert captured.out == "1012.5true"
 
 
 def test_file_operations(tmp_path):

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -79,9 +79,18 @@ def test_llvm_ffi_time_random():
     assert isinstance(res_rand, int)
 
 def test_llvm_print_functions(capfd):
-    compile_and_run('print(101); print(true);')
+    src = (
+        'func main() -> nil {\n'
+        '    let i = 101;\n'
+        '    let f = 2.5;\n'
+        '    print(i);\n'
+        '    print(f);\n'
+        '    print(true);\n'
+        '}'
+    )
+    compile_and_run(src)
     captured = capfd.readouterr()
-    assert captured.out == "101true"
+    assert captured.out == "1012.5true"
 
 
 def test_llvm_file_operations(tmp_path):


### PR DESCRIPTION
## Summary
- convert variable arguments in the LLVM generator so that `print` receives real runtime objects
- extend print tests to cover printing integer and float variables

## Testing
- `pytest -k print_functions -vv`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6866104cec2c8321ac3420b00747485d