### PR TITLE
Implement MXString runtime and LLVM support

### DIFF
--- a/runtime/impl/string.cpp
+++ b/runtime/impl/string.cpp
@@ -1,0 +1,21 @@
+#include "string.hpp"
+#include "allocator.hpp"
+
+namespace mxs_runtime {
+
+    static const RTTI RTTI_STRING{ "String" };
+
+    MXString::MXString(inner_string v)
+        : MXObject(&RTTI_STRING, false), value(std::move(v)) { }
+
+    auto MXString::repr() const -> inner_string { return value; }
+
+}// namespace mxs_runtime
+
+extern "C" MXS_API auto MXCreateString(const char *c_str) -> mxs_runtime::MXString * {
+    if (!c_str) return nullptr;
+    auto *obj = new mxs_runtime::MXString(mxs_runtime::inner_string(c_str));
+    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
+    obj->increase_ref();
+    return obj;
+}

--- a/runtime/include/string.hpp
+++ b/runtime/include/string.hpp
@@ -2,10 +2,21 @@
 #ifndef MX_OBJECT_STRING_HPP
 #define MX_OBJECT_STRING_HPP
 
+#include "_typedef.hpp"
+#include "macro.hpp"
 #include "object.hpp"
 
 namespace mxs_runtime {
-    class MXString : MXObject { };
-}
-// C API:
-#endif//MX_OBJECT_NUMERIC_HPP
+
+    class MXString : public MXObject {
+    public:
+        inner_string value;
+        explicit MXString(inner_string v);
+        auto repr() const -> inner_string override;
+    };
+
+    MXS_API MXString *MXCreateString(const char *c_str);
+
+}// namespace mxs_runtime
+
+#endif// MX_OBJECT_STRING_HPP

--- a/src/backend/compiler.py
+++ b/src/backend/compiler.py
@@ -631,13 +631,10 @@ def _compile_expr(
             return code
         for arg in expr.args:
             special_print = expr.name == "print" and isinstance(
-                arg, (String, Integer, Float, Boolean, NilLiteral)
+                arg, (Integer, Float, Boolean, NilLiteral)
             )
             if special_print:
-                if isinstance(arg, String):
-                    code.append(Const(arg.value))
-                    code.append(Call("MXCreateString", 1))
-                elif isinstance(arg, Integer):
+                if isinstance(arg, Integer):
                     code.append(Const(arg.value))
                     code.append(Call("MXCreateInteger", 1))
                 elif isinstance(arg, Float):

--- a/src/backend/llvm/generator.py
+++ b/src/backend/llvm/generator.py
@@ -147,7 +147,10 @@ class LLVMGenerator:
                 continue
             if isinstance(instr, Const):
                 if isinstance(instr.value, str):
-                    stack.append(self._create_global_string(instr.value))
+                    cstr_ptr = self._create_global_string(instr.value)
+                    create_fn = self.ffi.get_or_declare_function("MXCreateString")
+                    obj = self.ctx.builder.call(create_fn, [cstr_ptr])
+                    stack.append(obj)
                 elif isinstance(instr.value, bool):
                     stack.append(ir.Constant(ir.IntType(1), int(instr.value)))
                 elif isinstance(instr.value, int):

--- a/tests/test_llvm_backend.py
+++ b/tests/test_llvm_backend.py
@@ -93,6 +93,12 @@ def test_llvm_print_functions(capfd):
     assert captured.out == "1012.5true"
 
 
+def test_print_string_literal(capfd):
+    compile_and_run('print("Hello, MxScript!");')
+    captured = capfd.readouterr()
+    assert captured.out == "Hello, MxScript!"
+
+
 def test_llvm_file_operations(tmp_path):
     path = tmp_path / "out.txt"
     src = (


### PR DESCRIPTION
## Summary
- add `MXString` runtime type and creation function
- create `MXCreateString` in LLVM generator for string literals
- update compiler print helper for new string object
- test printing a string literal

## Testing
- `pytest tests/test_llvm_backend.py::test_print_string_literal -q`

------
https://chatgpt.com/codex/tasks/task_b_68661425f03c83219a0af090ec43dcdf