### PR TITLE
Fix runtime C API symbol conflict

### DIFF
--- a/runtime/include/typeinfo.h
+++ b/runtime/include/typeinfo.h
@@ -16,18 +16,22 @@ namespace mxs_runtime {
         MXObject *(*op_sub)(MXObject *, MXObject *);
         MXObject *(*op_eq)(MXObject *, MXObject *);
     };
-
-    extern "C" {
-    MXS_API mxs_runtime::MXObject *integer_add_integer(mxs_runtime::MXObject *,
-                                                       mxs_runtime::MXObject *);
-    MXS_API mxs_runtime::MXObject *integer_sub_integer(mxs_runtime::MXObject *,
-                                                       mxs_runtime::MXObject *);
-    MXS_API mxs_runtime::MXObject *mxs_op_add(mxs_runtime::MXObject *,
-                                              mxs_runtime::MXObject *);
-    MXS_API mxs_runtime::MXObject *mxs_op_sub(mxs_runtime::MXObject *,
-                                              mxs_runtime::MXObject *);
-    MXS_API mxs_runtime::inner_integer mxs_get_integer_value(mxs_runtime::MXObject *);
-    }
 }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+MXS_API mxs_runtime::MXObject *integer_add_integer(mxs_runtime::MXObject *,
+                                                   mxs_runtime::MXObject *);
+MXS_API mxs_runtime::MXObject *integer_sub_integer(mxs_runtime::MXObject *,
+                                                   mxs_runtime::MXObject *);
+MXS_API mxs_runtime::MXObject *mxs_op_add(mxs_runtime::MXObject *,
+                                          mxs_runtime::MXObject *);
+MXS_API mxs_runtime::MXObject *mxs_op_sub(mxs_runtime::MXObject *,
+                                          mxs_runtime::MXObject *);
+MXS_API mxs_runtime::inner_integer mxs_get_integer_value(mxs_runtime::MXObject *);
+#ifdef __cplusplus
+}
+#endif
 
 #endif// MXS_TYPEINFO_H


### PR DESCRIPTION
## Summary
- move C API declarations in `typeinfo.h` outside the `mxs_runtime` namespace
- rebuild runtime to verify it compiles

## Testing
- `cmake --build .`
- `pytest -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_68662fbe640c832185436b92180fd8c2