### PR TITLE
Implement print end parameter

### DIFF
--- a/runtime/impl/functions.cpp
+++ b/runtime/impl/functions.cpp
@@ -4,6 +4,7 @@
 #include "nil.hpp"
 #include "numeric.hpp"
 #include "object.h"
+#include "string.hpp"
 #include <cstddef>
 #include <cstdio>
 #include <iostream>
@@ -26,8 +27,13 @@ namespace mxs_runtime {
     auto type_of(const MXObject &obj) -> inner_string { return obj.get_type_name(); }
 }
 
-extern "C" auto mxs_print_object(mxs_runtime::MXObject *obj) -> std::size_t {
+extern "C" auto mxs_print_object_ext(mxs_runtime::MXObject *obj,
+                                     mxs_runtime::MXObject *end)
+        -> mxs_runtime::MXObject * {
     auto text = obj->repr();
-    std::print("{}", text);
-    return text.length();
+    auto *end_str = dynamic_cast<mxs_runtime::MXString *>(end);
+    auto suffix = end_str ? end_str->value : mxs_runtime::inner_string{};
+    std::print("{}{}", text, suffix);
+    return const_cast<mxs_runtime::MXObject *>(
+            reinterpret_cast<const mxs_runtime::MXObject *>(mxs_get_nil()));
 }

--- a/runtime/include/functions.hpp
+++ b/runtime/include/functions.hpp
@@ -10,5 +10,6 @@ namespace mxs_runtime {
     inner_string type_of(const MXObject &obj);
 }
 
-extern "C" std::size_t mxs_print_object(mxs_runtime::MXObject *obj);
+extern "C" mxs_runtime::MXObject *mxs_print_object_ext(mxs_runtime::MXObject *obj,
+                                                       mxs_runtime::MXObject *end);
 #endif// MX_FUNCTIONS_HPP

--- a/src/backend/compiler.py
+++ b/src/backend/compiler.py
@@ -75,7 +75,7 @@ _label_counter = 0
 _temp_counter = 0
 
 # Mapping of builtin function names to their runtime implementation
-BUILTIN_FUNCTIONS = {"print": "mxs_print_object"}
+BUILTIN_FUNCTIONS = {"print": "mxs_print_object_ext"}
 
 
 def _new_label(prefix: str) -> str:

--- a/src/backend/ffi_map.json
+++ b/src/backend/ffi_map.json
@@ -48,9 +48,10 @@
             "cstr_ptr"
         ]
     },
-    "mxs_print_object": {
-        "ret": "int64",
+    "mxs_print_object_ext": {
+        "ret": "char_ptr",
         "args": [
+            "char_ptr",
             "char_ptr"
         ]
     },

--- a/src/backend/llvm/generator.py
+++ b/src/backend/llvm/generator.py
@@ -315,7 +315,7 @@ class LLVMGenerator:
                     func_ty = ir.FunctionType(ret_ty, arg_tys)
                 except KeyError:
                     func_ty = callee.function_type
-                if instr.name == "mxs_print_object" and args:
+                if instr.name == "mxs_print_object_ext" and args:
                     obj_arg = args[0]
                     if isinstance(obj_arg.type, ir.IntType):
                         if obj_arg.type.width == 1:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -42,10 +42,12 @@ def test_backend_import_hello_world():
     ir = compile_and_run_file(Path("demo_program/examples/hello_world.mxs"))
     assert "io.println" in ir.functions
 
+
 def test_auto_main_call():
     src = "func main() -> int { return 42; }"
     result = compile_and_run(src)
     assert result == 42
+
 
 def test_backend_return_statement():
     src = "func foo() { return 1; 2; } foo();"
@@ -55,29 +57,43 @@ def test_backend_return_statement():
 
 def test_print_functions(capfd):
     src = (
-        'func main() -> nil {\n'
-        '    let i = 101;\n'
-        '    let f = 2.5;\n'
-        '    print(i);\n'
-        '    print(f);\n'
-        '    print(true);\n'
-        '}'
+        "func main() -> nil {\n"
+        "    let i = 101;\n"
+        "    let f = 2.5;\n"
+        "    print(i);\n"
+        "    print(f);\n"
+        "    print(true);\n"
+        "}"
     )
     compile_and_run(src)
     captured = capfd.readouterr()
-    assert captured.out == "1012.5true"
+    assert captured.out == "101\n2.5\ntrue\n"
+
+
+def test_print_end_variations(capfd):
+    compile_and_run('print("Hello");')
+    captured = capfd.readouterr()
+    assert captured.out == "Hello\n"
+
+    compile_and_run('print("Hello", end="");')
+    captured = capfd.readouterr()
+    assert captured.out == "Hello"
+
+    compile_and_run('print("Hello", end="-->");')
+    captured = capfd.readouterr()
+    assert captured.out == "Hello-->"
 
 
 def test_file_operations(tmp_path):
     path = tmp_path / "out.txt"
     src = (
-        f'import std.io as io;\n'
-        f'func main() -> int {{\n'
+        f"import std.io as io;\n"
+        f"func main() -> int {{\n"
         f'    let fd = io.open_file("{path}", 577, 438);\n'
         f'    io.write_file(fd, "hello");\n'
-        f'    io.close_file(fd);\n'
-        f'    return 0;\n'
-        f'}}'
+        f"    io.close_file(fd);\n"
+        f"    return 0;\n"
+        f"}}"
     )
     result = compile_and_run(src)
     assert result == 0
@@ -86,12 +102,12 @@ def test_file_operations(tmp_path):
 
 def test_static_alias_println(capfd):
     src = (
-        'import std.io as io;\n'
-        'static let println = io.println;\n'
-        'func main() -> int {\n'
+        "import std.io as io;\n"
+        "static let println = io.println;\n"
+        "func main() -> int {\n"
         '    println("hi");\n'
-        '    return 0;\n'
-        '}'
+        "    return 0;\n"
+        "}"
     )
     result = compile_and_run(src)
     captured = capfd.readouterr()
@@ -101,15 +117,15 @@ def test_static_alias_println(capfd):
 
 def test_constructor_call(capfd):
     src = (
-        'import std.io as io;\n'
-        'class Box {\n'
+        "import std.io as io;\n"
+        "class Box {\n"
         '    Box() { io.println("ctor"); }\n'
         '    ~Box() { io.println("dtor"); }\n'
-        '}\n'
-        'func main() -> int {\n'
-        '    let b: Box = Box();\n'
-        '    return 0;\n'
-        '}'
+        "}\n"
+        "func main() -> int {\n"
+        "    let b: Box = Box();\n"
+        "    return 0;\n"
+        "}"
     )
     compile_and_run(src)
     captured = capfd.readouterr()
@@ -118,52 +134,53 @@ def test_constructor_call(capfd):
 
 def test_destructors_scopes(capfd):
     src = (
-        'import std.io as io;\n'
+        "import std.io as io;\n"
         'class G { ~G() { io.println("dg"); } }\n'
         'class Outer { ~Outer() { io.println("do"); } }\n'
         'class Inner { ~Inner() { io.println("di"); } }\n'
-        'let g: G = 0;\n'
-        'func main() -> int {\n'
-        '    let x: Outer = 0;\n'
-        '    {\n'
-        '        let x: Inner = 0;\n'
+        "let g: G = 0;\n"
+        "func main() -> int {\n"
+        "    let x: Outer = 0;\n"
+        "    {\n"
+        "        let x: Inner = 0;\n"
         '        io.println("inner");\n'
-        '    }\n'
+        "    }\n"
         '    io.println("outer");\n'
-        '    return 0;\n'
-        '}\n'
+        "    return 0;\n"
+        "}\n"
     )
     pytest.skip("Destructor semantics not fully implemented")
 
 
 def test_destructor_inferred_type(capfd):
     src = (
-        'import std.io as io;\n'
-        'class Box {\n'
-        '    Box() {}\n'
+        "import std.io as io;\n"
+        "class Box {\n"
+        "    Box() {}\n"
         '    ~Box() { io.println("drop"); }\n'
-        '}\n'
-        'func main() -> int {\n'
-        '    let b = Box();\n'
-        '    return 0;\n'
-        '}\n'
+        "}\n"
+        "func main() -> int {\n"
+        "    let b = Box();\n"
+        "    return 0;\n"
+        "}\n"
     )
     pytest.skip("Destructor semantics not fully implemented")
 
+
 def test_destructor_call(capfd):
     src = (
-        'import std.io as io;\n'
-        'class Loud {\n'
-        '    ~Loud() {\n'
+        "import std.io as io;\n"
+        "class Loud {\n"
+        "    ~Loud() {\n"
         '        io.println("Object destroyed!");\n'
-        '    }\n'
-        '}\n'
-        'func main() -> int {\n'
+        "    }\n"
+        "}\n"
+        "func main() -> int {\n"
         '    io.println("Creating object...");\n'
-        '    let obj: Loud = 0;\n'
+        "    let obj: Loud = 0;\n"
         '    io.println("Object created. Exiting main...");\n'
-        '    return 0;\n'
-        '}'
+        "    return 0;\n"
+        "}"
     )
     compile_and_run(src)
     captured = capfd.readouterr()
@@ -172,15 +189,15 @@ def test_destructor_call(capfd):
 
 def test_constructor_and_destructor_call(capfd):
     src = (
-        'import std.io as io;\n'
-        'class Box {\n'
+        "import std.io as io;\n"
+        "class Box {\n"
         '    Box() { io.println("ctor"); }\n'
         '    ~Box() { io.println("dtor"); }\n'
-        '}\n'
-        'func main() -> int {\n'
-        '    let b: Box = Box();\n'
-        '    return 0;\n'
-        '}'
+        "}\n"
+        "func main() -> int {\n"
+        "    let b: Box = Box();\n"
+        "    return 0;\n"
+        "}"
     )
     compile_and_run(src)
     captured = capfd.readouterr()
@@ -197,8 +214,10 @@ def test_break_llir_generation():
     analyzer.analyze(ast)
     ir = compile_program(ast, analyzer.type_registry)
     from src.backend.llir import Br, Label
+
     labels = [instr.name for instr in ir.code if isinstance(instr, Label)]
     assert len(labels) >= 2
     break_target = labels[-1]
-    assert any(isinstance(instr, Br) and instr.label == break_target for instr in ir.code)
-
+    assert any(
+        isinstance(instr, Br) and instr.label == break_target for instr in ir.code
+    )


### PR DESCRIPTION
## Summary
- extend the builtin `print` signature with an `end` parameter
- support default newline in semantic analyser
- update runtime function `mxs_print_object_ext`
- map new ABI in `ffi_map.json`
- adjust LLVM generator and compiler for new builtin
- add tests for print `end` variations

## Testing
- `clang-format -i runtime/include/functions.hpp runtime/impl/functions.cpp`
- `black -q src/semantic_analyzer/analyzer.py tests/test_backend.py tests/test_llvm_backend.py`
- `cmake .. && cmake --build . -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_b_68663a99263c8321ac859ebfddc893b9