### PR TITLE
Implement MXList container

### DIFF
--- a/runtime/impl/container.cpp
+++ b/runtime/impl/container.cpp
@@ -1,0 +1,124 @@
+#include "container.hpp"
+#include "allocator.hpp"
+#include "typeinfo.h"
+#include "numeric.hpp"
+#include <stdexcept>
+
+namespace mxs_runtime {
+
+//============================
+// MXContainer base
+//============================
+MXContainer::MXContainer(const MXTypeInfo *info, bool is_static)
+    : MXObject(info, is_static) {}
+
+//============================
+// Type Info
+//============================
+static const MXTypeInfo g_list_type_info{
+    "List",
+    nullptr,
+    nullptr,
+    nullptr,
+    nullptr
+};
+
+//============================
+// MXList Implementation
+//============================
+MXList::MXList(bool is_static)
+    : MXContainer(&g_list_type_info, is_static) {}
+
+MXList::~MXList() {
+    for (MXObject* elem : elements) {
+        ::decrease_ref(elem);
+    }
+}
+
+auto MXList::length() const -> std::size_t { return elements.size(); }
+
+auto MXList::contains(const MXObject& obj) const -> bool {
+    for (MXObject* e : elements) {
+        if (e->equals(&obj)) return true;
+    }
+    return false;
+}
+
+auto MXList::op_getitem(const MXObject& key) const -> MXObject* {
+    // only integer index allowed
+    if (std::string(key.get_type_name()) != "Integer") {
+        return new MXError();
+    }
+    auto idx = static_cast<const MXInteger&>(key).value;
+    if (idx < 0 || static_cast<std::size_t>(idx) >= elements.size()) {
+        return new MXError();
+    }
+    return elements[static_cast<std::size_t>(idx)];
+}
+
+auto MXList::op_setitem(const MXObject& key, MXObject& value) -> void {
+    if (std::string(key.get_type_name()) != "Integer") {
+        return;
+    }
+    auto idx = static_cast<const MXInteger&>(key).value;
+    if (idx < 0 || static_cast<std::size_t>(idx) >= elements.size()) {
+        return;
+    }
+    std::size_t i = static_cast<std::size_t>(idx);
+    MXObject* old = elements[i];
+    ::increase_ref(&value);
+    elements[i] = &value;
+    ::decrease_ref(old);
+}
+
+auto MXList::op_append(MXObject& value) -> void {
+    ::increase_ref(&value);
+    elements.push_back(&value);
+}
+
+//============================
+// C API
+//============================
+extern "C" {
+MXS_API MXList* MXCreateList() {
+    auto* obj = new MXList(false);
+    MX_ALLOCATOR.registerObject(obj);
+    obj->increase_ref();
+    return obj;
+}
+
+MXS_API MXObject* list_getitem(MXObject* list, MXObject* index) {
+    if (!list) return new MXError();
+    auto* l = dynamic_cast<MXList*>(list);
+    if (!l) return new MXError();
+    return l->op_getitem(*index);
+}
+
+MXS_API void list_setitem(MXObject* list, MXObject* index, MXObject* value) {
+    if (!list) return;
+    auto* l = dynamic_cast<MXList*>(list);
+    if (!l) return;
+    l->op_setitem(*index, *value);
+}
+
+MXS_API void list_append(MXObject* list, MXObject* value) {
+    if (!list) return;
+    auto* l = dynamic_cast<MXList*>(list);
+    if (!l) return;
+    l->op_append(*value);
+}
+
+MXS_API MXObject* mxs_op_getitem(MXObject* container, MXObject* key) {
+    auto* l = dynamic_cast<MXList*>(container);
+    if (l) return l->op_getitem(*key);
+    return new MXError();
+}
+
+MXS_API void mxs_op_setitem(MXObject* container, MXObject* key, MXObject* value) {
+    auto* l = dynamic_cast<MXList*>(container);
+    if (l) l->op_setitem(*key, *value);
+}
+} // extern "C"
+
+} // namespace mxs_runtime
+

--- a/runtime/include/container.hpp
+++ b/runtime/include/container.hpp
@@ -34,12 +34,13 @@ namespace mxs_runtime {
     /**
      * @brief A mutable, ordered sequence of objects. Analogous to Python's list.
      */
-    class MXList : public MXContainer {
-    public:
-        std::vector<MXObject*> elements;
+class MXList : public MXContainer {
+public:
+    std::vector<MXObject*> elements;
 
-        explicit MXList(bool is_static = false);
-        auto length() const -> std::size_t override;
+    explicit MXList(bool is_static = false);
+    ~MXList();
+    auto length() const -> std::size_t override;
         auto contains(const MXObject& obj) const -> bool override;
 
         // --- VTable Operations ---

--- a/runtime/include/numeric.hpp
+++ b/runtime/include/numeric.hpp
@@ -29,10 +29,11 @@ namespace mxs_runtime {
     /**
      * @brief Represents a 64-bit integer.
      */
-    class MXInteger : public MXNumeric {
-    public:
-        const inner_integer value;
-        explicit MXInteger(inner_integer v);
+class MXInteger : public MXNumeric {
+public:
+    const inner_integer value;
+    explicit MXInteger(inner_integer v);
+    auto to_string() const -> std::string override;
         // ... other methods ...
 
         // --- Operator Declarations for VTable ---
@@ -52,10 +53,11 @@ namespace mxs_runtime {
     /**
      * @brief Represents a 64-bit float (double).
      */
-    class MXFloat : public MXNumeric {
-    public:
-        const inner_float value;
-        explicit MXFloat(inner_float v);
+class MXFloat : public MXNumeric {
+public:
+    const inner_float value;
+    explicit MXFloat(inner_float v);
+    auto to_string() const -> std::string override;
         // ... other methods ...
 
         // --- Operator Declarations for VTable ---
@@ -81,26 +83,26 @@ extern "C"
    //======================================================================
     // C API for Runtime Object Creation
     //======================================================================
-    MXS_API MXInteger *MXCreateInteger(inner_integer value);
-    MXS_API MXFloat *MXCreateFloat(inner_float value);
+MXS_API mxs_runtime::MXInteger *MXCreateInteger(mxs_runtime::inner_integer value);
+MXS_API mxs_runtime::MXFloat *MXCreateFloat(mxs_runtime::inner_float value);
 
     //======================================================================
     // C API for Static Dispatch ("Fast Path")
     //======================================================================
 
     // --- Arithmetic ---
-    MXS_API MXObject *integer_add_integer(MXObject *left, MXObject *right);
+MXS_API mxs_runtime::MXObject *integer_add_integer(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
     // ... other arithmetic functions ...
 
     // --- Comparison (returns MXBoolean) ---
-    MXS_API MXObject *integer_eq_integer(MXObject *left, MXObject *right);
-    MXS_API MXObject *integer_gt_integer(MXObject *left, MXObject *right);
+    MXS_API mxs_runtime::MXObject *integer_eq_integer(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *integer_gt_integer(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
     // ... other integer/float comparison combinations ...
 
     // --- Logical (on MXBoolean objects) ---
-    MXS_API MXObject *boolean_and_boolean(MXObject *left, MXObject *right);
-    MXS_API MXObject *boolean_or_boolean(MXObject *left, MXObject *right);
-    MXS_API MXObject *boolean_not(MXObject *operand);
+    MXS_API mxs_runtime::MXObject *boolean_and_boolean(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *boolean_or_boolean(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *boolean_not(mxs_runtime::MXObject *operand);
 
 
     //======================================================================
@@ -108,24 +110,24 @@ extern "C"
     //======================================================================
 
     // --- Arithmetic ---
-    MXS_API MXObject *mxs_op_add(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_sub(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_mul(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_div(MXObject *left, MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_add(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_sub(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_mul(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_div(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
 
     // --- Comparison ---
-    MXS_API MXObject *mxs_op_eq(MXObject *left, MXObject *right); // Corresponds to `==`
-    MXS_API MXObject *mxs_op_ne(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_lt(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_le(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_gt(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_ge(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_is(MXObject *left, MXObject *right); // Corresponds to `is`
+    MXS_API mxs_runtime::MXObject *mxs_op_eq(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right); // Corresponds to `==`
+    MXS_API mxs_runtime::MXObject *mxs_op_ne(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_lt(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_le(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_gt(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_ge(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_is(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right); // Corresponds to `is`
 
     // --- Logical ---
-    MXS_API MXObject *mxs_op_and(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_or(MXObject *left, MXObject *right);
-    MXS_API MXObject *mxs_op_not(MXObject *operand); // Unary operator
+    MXS_API mxs_runtime::MXObject *mxs_op_and(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_or(mxs_runtime::MXObject *left, mxs_runtime::MXObject *right);
+    MXS_API mxs_runtime::MXObject *mxs_op_not(mxs_runtime::MXObject *operand); // Unary operator
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- add `MXList` destructor and container operations
- support creation and manipulation of lists via C API
- fix numeric header to use fully-qualified names and declare `to_string`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_b_6866613cdb908321b11bdd92fce0335a