### PR TITLE
Add FFI target helper functions in runtime

### DIFF
--- a/runtime/impl/numeric.cpp
+++ b/runtime/impl/numeric.cpp
@@ -7,7 +7,7 @@ namespace mxs_runtime {
 
 
     static const MXTypeInfo g_numeric_type_info{ "Numeric", nullptr };
-    static const MXTypeInfo g_integer_type_info{ "Integer", &g_numeric_type_info };
+    MXS_API const MXTypeInfo g_integer_type_info{ "Integer", &g_numeric_type_info };
     static const MXTypeInfo g_float_type_info{ "Float", &g_numeric_type_info };
 
     MXNumeric::MXNumeric(const MXTypeInfo *info, bool is_static)
@@ -850,6 +850,16 @@ MXS_API mxs_runtime::MXObject *mxs_op_is(mxs_runtime::MXObject *left,
 MXS_API mxs_runtime::inner_integer mxs_get_integer_value(mxs_runtime::MXObject *obj) {
     auto *i = static_cast<mxs_runtime::MXInteger *>(obj);
     return i->value;
+}
+
+MXS_API mxs_runtime::MXObject *mxs_int_absolute(mxs_runtime::MXObject *integer_obj) {
+    using namespace mxs_runtime;
+    if (!integer_obj || integer_obj->type_info != &g_integer_type_info) {
+        return new MXError("TypeError", "Argument must be an Integer.");
+    }
+    auto val = static_cast<MXInteger *>(integer_obj)->value;
+    if (val < 0) val = -val;
+    return MXCreateInteger(val);
 }
 
 auto MXCreateInteger(mxs_runtime::inner_integer value) -> mxs_runtime::MXInteger * {

--- a/runtime/impl/string.cpp
+++ b/runtime/impl/string.cpp
@@ -1,5 +1,6 @@
 #include "string.hpp"
 #include "allocator.hpp"
+#include "numeric.hpp"
 #include "typeinfo.h"
 
 namespace mxs_runtime {
@@ -19,4 +20,15 @@ extern "C" MXS_API auto MXCreateString(const char *c_str) -> mxs_runtime::MXStri
     mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     obj->increase_ref();
     return obj;
+}
+
+extern "C" MXS_API auto mxs_string_from_integer(mxs_runtime::MXObject *integer_obj)
+        -> mxs_runtime::MXObject * {
+    using namespace mxs_runtime;
+    if (!integer_obj || integer_obj->type_info != &g_integer_type_info) {
+        return new MXError("TypeError", "Argument must be an Integer.");
+    }
+    auto val = static_cast<MXInteger *>(integer_obj)->value;
+    auto str = std::to_string(val);
+    return mxs_runtime::MXCreateString(str.c_str());
 }

--- a/runtime/include/numeric.hpp
+++ b/runtime/include/numeric.hpp
@@ -16,6 +16,8 @@ namespace mxs_runtime {
     class MXFloat;
     class MXBoolean;
 
+    extern MXS_API const MXTypeInfo g_integer_type_info;
+
     /**
      * @brief Base class for all numeric types.
      */
@@ -230,6 +232,8 @@ MXS_API mxs_runtime::MXObject *mxs_op_or(mxs_runtime::MXObject *left,
                                          mxs_runtime::MXObject *right);
 MXS_API mxs_runtime::MXObject *
 mxs_op_not(mxs_runtime::MXObject *operand);// Unary operator
+
+MXS_API mxs_runtime::MXObject *mxs_int_absolute(mxs_runtime::MXObject *integer_obj);
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/string.hpp
+++ b/runtime/include/string.hpp
@@ -20,4 +20,13 @@ namespace mxs_runtime {
 
 }// namespace mxs_runtime
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+MXS_API mxs_runtime::MXObject *
+mxs_string_from_integer(mxs_runtime::MXObject *integer_obj);
+#ifdef __cplusplus
+}
+#endif
+
 #endif// MX_OBJECT_STRING_HPP


### PR DESCRIPTION
## Summary
- expose `g_integer_type_info` for other modules
- add `mxs_string_from_integer` to convert integers to strings
- implement `mxs_int_absolute` returning absolute integer values
- declare new APIs in headers
- rebuild runtime library

## Testing
- `bash scripts/rebuild_runtime.sh`
- `pytest -q` *(fails: TypeError during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68677168f2e88321a5b5681775b7e4f0