### PR TITLE
Implement builtin module and cast sugar

### DIFF
--- a/stdlib/_builtin.mxs
+++ b/stdlib/_builtin.mxs
@@ -1,0 +1,7 @@
+class String {
+    @@foreign(lib="runtime.so", symbol_name="mxs_string_from_integer")
+    static func from(value: Integer) -> String;
+}
+
+@@foreign(lib="runtime.so", symbol_name="mxs_int_absolute")
+func abs(value: Integer) -> Integer;


### PR DESCRIPTION
## Summary
- introduce `_builtin.mxs` providing initial FFI bindings
- load `_builtin.mxs` automatically before compiling user code
- expand semantic analyzer to translate `cast(T, v)` to `T.from(v)`

## Testing
- `pytest -q` *(fails: TypeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_b_68677919ba348321bbcf8fb63ff8fcfc