### PR TITLE
Fix FFI registration and remove static dispatch logic

### DIFF
--- a/src/backend/abi_manager.py
+++ b/src/backend/abi_manager.py
@@ -19,20 +19,29 @@ _TYPE_MAP = {
 }
 
 _PATH = Path(__file__).with_name("ffi_map.json")
-_RAW_MAP: Dict[str, dict] = json.loads(_PATH.read_text())
+_RAW_MAP = json.loads(_PATH.read_text())
 _TYPED_MAP: Dict[str, dict] = {}
-for name, info in _RAW_MAP.items():
-    entry = {
-        "ret": _TYPE_MAP[info["ret"]],
-        "args": [_TYPE_MAP[a] for a in info["args"]],
-    }
-    if "name" in info:
-        entry["name"] = info["name"]
-    if "wrapper_args" in info:
-        entry["wrapper_args"] = [_TYPE_MAP[a] for a in info["wrapper_args"]]
-    if "var_arg" in info:
-        entry["var_arg"] = info["var_arg"]
-    _TYPED_MAP[name] = entry
+
+if "ffi_functions" in _RAW_MAP:
+    # Minimal map containing only names of FFI-exposed functions
+    if "mxs_ffi_call" in _RAW_MAP["ffi_functions"]:
+        _TYPED_MAP["mxs_ffi_call"] = {
+            "ret": char_ptr,
+            "args": [char_ptr, char_ptr, int32, char_ptr.as_pointer()],
+        }
+else:
+    for name, info in _RAW_MAP.items():
+        entry = {
+            "ret": _TYPE_MAP[info["ret"]],
+            "args": [_TYPE_MAP[a] for a in info["args"]],
+        }
+        if "name" in info:
+            entry["name"] = info["name"]
+        if "wrapper_args" in info:
+            entry["wrapper_args"] = [_TYPE_MAP[a] for a in info["wrapper_args"]]
+        if "var_arg" in info:
+            entry["var_arg"] = info["var_arg"]
+        _TYPED_MAP[name] = entry
 
 
 def get_function_signature(name: str) -> Tuple[ir.Type, List[ir.Type]]:

--- a/src/backend/ffi_map.json
+++ b/src/backend/ffi_map.json
@@ -1,3 +1,205 @@
 {
-  "ffi_functions": ["mxs_ffi_call"]
+    "printf": {
+        "ret": "int32",
+        "args": [
+            "cstr_ptr"
+        ],
+        "var_arg": true
+    },
+    "write": {
+        "ret": "int64",
+        "args": [
+            "int32",
+            "cstr_ptr",
+            "int64"
+        ]
+    },
+    "read": {
+        "ret": "int64",
+        "args": [
+            "int32",
+            "cstr_ptr",
+            "int64"
+        ]
+    },
+    "open": {
+        "ret": "int64",
+        "args": [
+            "cstr_ptr",
+            "int32",
+            "int32"
+        ]
+    },
+    "close": {
+        "ret": "int32",
+        "args": [
+            "int32"
+        ]
+    },
+    "malloc": {
+        "ret": "cstr_ptr",
+        "args": [
+            "int64"
+        ]
+    },
+    "free": {
+        "ret": "void",
+        "args": [
+            "cstr_ptr"
+        ]
+    },
+    "mxs_print_object_ext": {
+        "ret": "char_ptr",
+        "args": [
+            "char_ptr",
+            "char_ptr"
+        ]
+    },
+    "new_mx_object": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "increase_ref": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    },
+    "decrease_ref": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    },
+    "MXCreateInteger": {
+        "ret": "char_ptr",
+        "args": [
+            "int64"
+        ]
+    },
+    "MXCreateFloat": {
+        "ret": "char_ptr",
+        "args": [
+            "double"
+        ]
+    },
+    "MXCreateString": {
+        "ret": "char_ptr",
+        "args": [
+            "cstr_ptr"
+        ]
+    },
+    "mxs_get_true": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "mxs_get_false": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "mxs_get_nil": {
+        "ret": "char_ptr",
+        "args": []
+    },
+    "time_now": {
+        "name": "time",
+        "ret": "int64",
+        "args": [
+            "cstr_ptr"
+        ],
+        "wrapper_args": []
+    },
+    "random_rand": {
+        "name": "rand",
+        "ret": "int32",
+        "args": [],
+        "wrapper_args": []
+    },
+    "strlen": {
+        "ret": "int64",
+        "args": [
+            "cstr_ptr"
+        ]
+    },
+    "integer_add_integer": {
+        "ret": "char_ptr",
+        "args": [
+            "char_ptr",
+            "char_ptr"
+        ]
+    },
+    "integer_sub_integer": {
+        "ret": "char_ptr",
+        "args": [
+            "char_ptr",
+            "char_ptr"
+        ]
+    },
+    "integer_add_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_add_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_add_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_sub_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_sub_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_sub_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_mul_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_mul_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_mul_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_mul_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_div_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_div_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_div_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_div_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_eq_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_eq_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_eq_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_eq_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_ne_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_ne_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_ne_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_ne_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_gt_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_gt_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_gt_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_gt_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_lt_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_lt_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_lt_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_lt_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_ge_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_ge_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_ge_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_ge_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_le_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "integer_le_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_le_integer": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "float_le_float": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_add": {
+        "ret": "char_ptr",
+        "args": [
+            "char_ptr",
+            "char_ptr"
+        ]
+    },
+    "mxs_op_sub": {
+        "ret": "char_ptr",
+        "args": [
+            "char_ptr",
+            "char_ptr"
+        ]
+    },
+    "mxs_op_mul": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_div": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_eq": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_ne": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_lt": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_le": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_gt": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_ge": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_op_is": {"ret": "char_ptr", "args": ["char_ptr", "char_ptr"]},
+    "mxs_get_integer_value": {
+        "ret": "int64",
+        "args": [
+            "char_ptr"
+        ]
+    }
 }

--- a/src/backend/llvm/generator.py
+++ b/src/backend/llvm/generator.py
@@ -27,11 +27,6 @@ from .context import LLVMContext
 from ..ffi import FFIManager
 from ..abi_manager import get_function_signature
 
-STATIC_DISPATCH_MAP = {
-    ("int", "+", "int"): "integer_add_integer",
-    ("int", "-", "int"): "integer_sub_integer",
-}
-
 DYNAMIC_DISPATCH_MAP = {
     "+": "mxs_op_add",
     "-": "mxs_op_sub",
@@ -326,17 +321,42 @@ class LLVMGenerator:
                 create_int = self.ffi.get_or_declare_function("MXCreateInteger")
                 a_obj = self.ctx.builder.call(create_int, [a])
                 b_obj = self.ctx.builder.call(create_int, [b])
-                func_name = STATIC_DISPATCH_MAP.get(key)
-                if func_name:
-                    self.ctx.builder.comment("STATIC dispatch")
-                    callee = self.ffi.get_or_declare_function(func_name)
-                else:
-                    self.ctx.builder.comment("DYNAMIC dispatch")
+                self.ctx.builder.comment("FFI dispatch")
+                symbol = None
+                if instr.left_type == "int" and instr.right_type == "int":
+                    if op == "+":
+                        symbol = "mxs_integer_add_integer"
+                    elif op == "-":
+                        symbol = "mxs_integer_sub_integer"
+                if symbol is None:
                     callee_name = DYNAMIC_DISPATCH_MAP.get(op)
                     if callee_name is None:
                         raise RuntimeError(f"Unsupported op {op}")
-                    callee = self.ffi.get_or_declare_function(callee_name)
-                obj_res = self.ctx.builder.call(callee, [a_obj, b_obj])
+                    symbol = callee_name
+                create_str = self.ffi.get_or_declare_function("MXCreateString")
+                lib_ptr = self._create_global_string("runtime.so")
+                lib_obj = self.ctx.builder.call(create_str, [lib_ptr])
+                sym_ptr = self._create_global_string(symbol)
+                sym_obj = self.ctx.builder.call(create_str, [sym_ptr])
+                arr = self.ctx.builder.alloca(
+                    self.ctx.obj_ptr_t,
+                    ir.Constant(self.ctx.int_t, 2),
+                )
+                for idx, obj in enumerate([a_obj, b_obj]):
+                    ptr = self.ctx.builder.gep(
+                        arr, [ir.Constant(self.ctx.int_t, idx)]
+                    )
+                    self.ctx.builder.store(obj, ptr)
+                ffi_fn = self.functions["mxs_ffi_call"]
+                obj_res = self.ctx.builder.call(
+                    ffi_fn,
+                    [
+                        lib_obj,
+                        sym_obj,
+                        ir.Constant(self.ctx.int_t, 2),
+                        arr,
+                    ],
+                )
                 get_val = self.ffi.get_or_declare_function("mxs_get_integer_value")
                 result = self.ctx.builder.call(get_val, [obj_res])
                 stack.append(result)

--- a/src/semantic_analyzer/analyzer.py
+++ b/src/semantic_analyzer/analyzer.py
@@ -60,6 +60,7 @@ class VarInfo:
     name: str
     type_name: str | None = None
     is_mut: bool = False
+    is_ffi: bool = False
 
 
 @dataclass
@@ -358,6 +359,10 @@ class SemanticAnalyzer:
                         self._visit_expression(p.default)
                 body = stmt.body.statements
                 skip_body = stmt.ffi_info is not None
+            if isinstance(stmt, FuncDef) and stmt.ffi_info is not None:
+                self._current_scope()[stmt.name] = VarInfo(
+                    stmt.name, None, False, True
+                )
             self.variables_stack.append(params)
             if not skip_body:
                 for s in body:

--- a/tests/test_static_dispatch.py
+++ b/tests/test_static_dispatch.py
@@ -14,10 +14,12 @@ def compile_ir(code: str) -> str:
 
 def test_integer_add_dispatch():
     ir = compile_ir("1 + 2;")
-    assert 'call i8* @\"integer_add_integer\"' in ir
+    assert 'mxs_ffi_call' in ir
+    assert 'mxs_integer_add_integer' in ir
     assert 'add i64' not in ir
 
 def test_integer_sub_dispatch():
     ir = compile_ir("1 - 2;")
-    assert 'call i8* @\"integer_sub_integer\"' in ir
+    assert 'mxs_ffi_call' in ir
+    assert 'mxs_integer_sub_integer' in ir
     assert 'sub i64' not in ir


### PR DESCRIPTION
## Summary
- register FFI stubs in semantic analyzer and mark with a flag
- update ABI manager to handle simplified ffi_map
- remove obsolete static dispatch map and generate FFI calls for binary ops
- restore complete ffi_map for tests
- update static dispatch tests

## Testing
- `PYTHONPATH=. pytest tests/test_static_dispatch.py -q`
- `PYTHONPATH=. pytest tests/test_semantic.py::test_semantic_foreign_function -q`
- `PYTHONPATH=. pytest -q` *(fails: 28 failed, 92 passed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_686789f7295083218ae7eb9b7d401cd0