### PR TITLE
Support method annotations

### DIFF
--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -173,6 +173,8 @@ class MethodDef(Statement):
     signature: FuncSig
     body: Block
     is_override: bool = False
+    template_params: list[str] | None = None
+    ffi_info: Dict[str, str] | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- extend AST `MethodDef` to hold `template_params` and `ffi_info`
- allow annotation tokens before class methods
- parse annotated class methods like top-level functions
- add parser tests for annotated methods and invalid member annotation

## Testing
- `pytest tests/test_parser.py -q`
- `pytest -q` *(fails: various backend and semantic tests)*

------
https://chatgpt.com/codex/tasks/task_b_6867b8a999348321a87db5db2ec0b550