### PR TITLE
Centralize MXObject registration

### DIFF
--- a/runtime/impl/container.cpp
+++ b/runtime/impl/container.cpp
@@ -95,7 +95,6 @@ extern "C" {
 #endif
 MXS_API mxs_runtime::MXList *MXCreateList() {
     auto *obj = new mxs_runtime::MXList(false);
-    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     obj->increase_ref();
     return obj;
 }

--- a/runtime/impl/numeric.cpp
+++ b/runtime/impl/numeric.cpp
@@ -956,13 +956,11 @@ MXS_API mxs_runtime::MXObject *mxs_int_absolute(mxs_runtime::MXObject *integer_o
 
 auto MXCreateInteger(mxs_runtime::inner_integer value) -> mxs_runtime::MXInteger * {
     auto *obj = new mxs_runtime::MXInteger(value);
-    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     return obj;
 }
 
 auto MXCreateFloat(mxs_runtime::inner_float value) -> mxs_runtime::MXFloat * {
     auto *obj = new mxs_runtime::MXFloat(value);
-    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     return obj;
 }
 #ifdef __cplusplus

--- a/runtime/impl/object.cpp
+++ b/runtime/impl/object.cpp
@@ -11,7 +11,13 @@ namespace mxs_runtime {
     static const MXTypeInfo OBJECT_TYPE_INFO{ "object", nullptr };
 
     MXObject::MXObject(const MXTypeInfo *info, bool is_static)
-        : type_info(info), _is_static(is_static) { }
+        : type_info(info), _is_static(is_static) {
+        MX_ALLOCATOR.registerObject(this);
+    }
+
+    MXObject::~MXObject() {
+        MX_ALLOCATOR.unregisterObject(this);
+    }
 
 
     MXObject::MXObject(const MXObject &other)

--- a/runtime/impl/string.cpp
+++ b/runtime/impl/string.cpp
@@ -17,7 +17,6 @@ namespace mxs_runtime {
 extern "C" MXS_API auto MXCreateString(const char *c_str) -> mxs_runtime::MXString * {
     if (!c_str) return nullptr;
     auto *obj = new mxs_runtime::MXString(mxs_runtime::inner_string(c_str));
-    mxs_runtime::MX_ALLOCATOR.registerObject(obj);
     obj->increase_ref();
     return obj;
 }

--- a/runtime/include/object.h
+++ b/runtime/include/object.h
@@ -21,7 +21,7 @@ namespace mxs_runtime {
     public:
         explicit MXObject(const MXTypeInfo *info, bool is_static = false);
         MXObject(const MXObject &other);
-        virtual ~MXObject() = default;
+        virtual ~MXObject();
 
         auto increase_ref() -> refer_count_type;
         auto decrease_ref() -> refer_count_type;


### PR DESCRIPTION
## Summary
- track MXObject lifetime automatically
- remove manual allocator registration when creating objects

## Testing
- `pytest -q` *(fails: FileNotFoundError, AssertionError, SemanticError)*

------
https://chatgpt.com/codex/tasks/task_b_6867b943a7588321a5da8eadd9e0c3f1