### PR TITLE
Fix union return type parsing

### DIFF
--- a/src/frontend/tokens.py
+++ b/src/frontend/tokens.py
@@ -91,6 +91,7 @@ class TokenType(Enum):
     SLASH_EQ = auto()
     AND_AND = auto()
     OR_OR = auto()
+    PIPE = auto()
     ARROW = auto()
     FAT_ARROW = auto()
     DOT = auto()
@@ -175,6 +176,7 @@ OPERATORS = {
     "/=": TokenType.SLASH_EQ,
     "&&": TokenType.AND_AND,
     "||": TokenType.OR_OR,
+    "|": TokenType.PIPE,
     "->": TokenType.ARROW,
     "=>": TokenType.FAT_ARROW,
     "+": TokenType.PLUS,

--- a/src/syntax_parser/ast.py
+++ b/src/syntax_parser/ast.py
@@ -152,7 +152,7 @@ class Parameter(Node):
 @dataclass
 class FuncSig(Node):
     params: List[Parameter]
-    return_type: str | None
+    return_type: List[str] | None
     var_arg: bool = False
 
 

--- a/src/syntax_parser/definition_parser.py
+++ b/src/syntax_parser/definition_parser.py
@@ -296,11 +296,14 @@ class DefinitionParserMixin:
                     self.stream.next()
                     params.append(self.parse_param())
         self._expect(TokenType.RPAREN)
-        return_type = None
+        return_types: list[str] | None = None
         if self.stream.peek().type == TokenType.ARROW:
             self.stream.next()
-            return_type = self.parse_type_spec()
-        return FuncSig(params, return_type, var_arg, loc=start)
+            return_types = [self.parse_type_spec()]
+            while self.stream.peek().type == TokenType.PIPE:
+                self.stream.next()
+                return_types.append(self.parse_type_spec())
+        return FuncSig(params, return_types, var_arg, loc=start)
 
     def parse_param(self) -> Parameter:
         names = [self._expect(TokenType.IDENTIFIER).value]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -139,10 +139,26 @@ def test_parse_func_def():
     assert len(func.signature.params) == 2
     assert func.signature.params[0].names == ["x"]
     assert func.signature.params[0].type_name == "int"
-    assert func.signature.return_type == "int"
+    assert func.signature.return_type == ["int"]
     assert isinstance(func.body, Block)
     assert len(func.body.statements) == 1
     assert isinstance(func.body.statements[0], LetStmt)
+
+
+def test_parse_union_return_type():
+    src = "func cast(target_type: Target, value: Origin) -> Target | Error {}"
+    program = parse(src)
+    func = program.statements[0]
+    assert isinstance(func, FuncDef)
+    assert func.signature.return_type == ["Target", "Error"]
+
+
+def test_parse_multiple_union_return_type():
+    src = "func process_data() -> String | Integer | Nil {}"
+    program = parse(src)
+    func = program.statements[0]
+    assert isinstance(func, FuncDef)
+    assert func.signature.return_type == ["String", "Integer", "Nil"]
 
 
 def test_nested_blocks():

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -82,3 +82,11 @@ def test_type_keywords_tokenization():
     assert "interface" in words
     assert "override" in words
     assert "static" in words
+
+
+def test_pipe_tokenization():
+    tokens = tokenize("func foo() -> int | Error {}")
+    values = [t.value for t in tokens if t.type != TokenType.COMMENT]
+    assert "|" in values
+    pipe_token = next(t for t in tokens if t.value == "|")
+    assert pipe_token.type == TokenType.PIPE


### PR DESCRIPTION
## Summary
- add PIPE token for '|'
- allow multiple return types in function signatures
- store return types as list on FuncSig
- test union return signatures and tokenization

## Testing
- `pytest tests/test_tokenizer.py::test_pipe_tokenization tests/test_parser.py::test_parse_union_return_type tests/test_parser.py::test_parse_multiple_union_return_type -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6867be6300508321890f8f6e4ef13193