### PR TITLE
Refactor FFI without libffi

### DIFF
--- a/runtime/include/ffi.hpp
+++ b/runtime/include/ffi.hpp
@@ -5,12 +5,14 @@
 #include "macro.hpp"
 #include "object.h"
 
-namespace mxs_runtime { }
+namespace mxs_runtime {
+    class MXObject;
+}
 
 extern "C" {
-MXS_API mxs_runtime::MXObject *mxs_ffi_call(mxs_runtime::MXObject *lib_name_obj,
-                                            mxs_runtime::MXObject *func_name_obj,
-                                            int argc, mxs_runtime::MXObject **argv);
+MXS_API mxs_runtime::MXObject *mxs_ffi_call(mxs_runtime::MXObject *lib,
+                                            mxs_runtime::MXObject *name,
+                                            mxs_runtime::MXObject *argv);
 MXS_API mxs_runtime::MXObject *mxs_variadic_print(mxs_runtime::MXObject *fmt,
                                                   mxs_runtime::MXObject *args);
 }


### PR DESCRIPTION
## Summary
- remove libffi-based dispatch from mxs_ffi_call
- restore pointer array dispatch table
- update exported mxs_ffi_call declaration

## Testing
- `pytest -q` *(fails: multiple tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_6868b88590788321869b167da91e3662