### PR TITLE
Implement variadic FFI printf wrapper

### DIFF
--- a/runtime/impl/builtin.cpp
+++ b/runtime/impl/builtin.cpp
@@ -1,0 +1,36 @@
+#include "builtin.hpp"
+#include <cstdio>
+#include <string>
+
+using namespace mxs_runtime;
+
+extern "C" MXS_API MXObject *printf_wrapper(MXObject *format_obj, MXObject *packed_obj) {
+    auto *fmt = dynamic_cast<MXString *>(format_obj);
+    auto *argv = dynamic_cast<MXFFICallArgv *>(packed_obj);
+    if (!fmt || !argv) {
+        return new MXError("TypeError", "expected String and FFICallArgv");
+    }
+
+    std::string out = fmt->value;
+    for (MXObject *elem : argv->args) {
+        out += " ";
+        if (auto *s = dynamic_cast<MXString *>(elem)) {
+            out += s->value;
+        } else if (auto *i = dynamic_cast<MXInteger *>(elem)) {
+            out += std::to_string(i->value);
+        } else if (auto *f = dynamic_cast<MXFloat *>(elem)) {
+            out += std::to_string(f->value);
+        } else if (auto *b = dynamic_cast<MXBoolean *>(elem)) {
+            out += b->value ? "true" : "false";
+        } else if (dynamic_cast<MXNil *>(elem)) {
+            out += "nil";
+        } else {
+            out += elem->repr();
+        }
+    }
+
+    int printed = std::printf("%s", out.c_str());
+    std::fflush(stdout);
+    return MXCreateInteger(static_cast<inner_integer>(printed));
+}
+

--- a/runtime/include/builtin.hpp
+++ b/runtime/include/builtin.hpp
@@ -10,4 +10,15 @@
 #include "object.h"
 #include "string.hpp"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MXS_API mxs_runtime::MXObject *printf_wrapper(mxs_runtime::MXObject *format,
+                                              mxs_runtime::MXObject *packed_argv);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -236,3 +236,18 @@ def test_ffi_variadic_call(capfd):
     captured = capfd.readouterr()
     assert "Hello world 123" in captured.out
     assert result == 0
+
+
+def test_printf_wrapper_variadic(capfd):
+    src = (
+        '@@foreign(lib="runtime.so", symbol_name="printf_wrapper", argv=[1,...])\n'
+        'func c_printf(fmt: String, ...) -> int;\n'
+        'func main() -> int {\n'
+        '    c_printf("Args:", "yay", 42);\n'
+        '    return 0;\n'
+        '}'
+    )
+    result = compile_and_run(src)
+    captured = capfd.readouterr()
+    assert "Args: yay 42" in captured.out
+    assert result >= 0


### PR DESCRIPTION
## Summary
- expose `printf_wrapper` in builtin header
- implement `printf_wrapper` in runtime
- test new variadic wrapper behaviour

## Testing
- `pytest -q` *(fails: LLVM IR parsing error and other failures)*

------
https://chatgpt.com/codex/tasks/task_b_6868d0f02d6c83218858db6aaa9621cb